### PR TITLE
Improve flexibility of resource generation script ROM paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /tables/dungeon/*.yaml
 /tables/img/
 /tables/old/
+/tables/zelda3.sfc
+/tables/zelda3.smc
 /saves/*.sav
 /.vs/
 __pycache__

--- a/tables/extract_resources.py
+++ b/tables/extract_resources.py
@@ -7,10 +7,22 @@ import tables
 import yaml
 import extract_music
 import os
+import getopt
 
 PATH=''
 
-ROM = util.LoadedRom()
+option_list, args = getopt.getopt(sys.argv[1:], 'r:', ['rom_path='])
+rom_path = None
+for opt, arg in option_list:
+  if opt in ('-r', '--rom_path'):
+    rom_path = arg
+
+try:
+  ROM = util.LoadedRom(rom_path)
+except Exception as error:
+  print(f"Failed to load ROM data for extraction. Error: {error}")
+  sys.exit(1)
+
 
 get_byte = ROM.get_byte
 get_word = ROM.get_word


### PR DESCRIPTION
changes:
1. Allows the user to copy in a ROM titled zelda3.smc, which is another common name/extension this ROM (file content should still be the same).
2. Allows the user to specify a location of the ROM file instead of copying the ROM to the directory where the script is located.
3. Adds and improves error messaging.

## Example output(s)
### SMC in default directory
```
keaton [~/GitHub/zelda3/tables] $ ls zelda3.sfc
ls: zelda3.sfc: No such file or directory
keaton [~/GitHub/zelda3/tables] $ ls zelda3.smc
zelda3.smc
keaton [~/GitHub/zelda3/tables] $ openssl dgst -sha256 zelda3.smc 
SHA256(zelda3.smc)= 66871d66be19ad2c34c927d6b14cd8eb6fc3181965b6e517cb361f7316009cfb
keaton [~/GitHub/zelda3/tables] $ python extract_resources.py 
keaton [~/GitHub/zelda3/tables] $ wc -l dialogue.txt 
     397 dialogue.txt
```

### User provided path (valid)
```
keaton [~/GitHub/zelda3/tables] $ rm dialogue.txt 
keaton [~/GitHub/zelda3/tables] $ python extract_resources.py --rom_path ~/Downloads/zelda_lttp.smc
keaton [~/GitHub/zelda3/tables] $ wc -l dialogue.txt 
     397 dialogue.txt
```

### User provided path (no file)
```
keaton [~/GitHub/zelda3/tables] $ python extract_resources.py --rom_path ~/Downloads/missing_rom.smc
Failed to load ROM data for extraction. Error: No ROM found at provided path /Users/keaton/Downloads/missing_rom.smc.
```

### User provided path (content mismatch)
```
keaton [~/GitHub/zelda3/tables] $ echo "hello" >> zelda3.sfc
keaton [~/GitHub/zelda3/tables] $ openssl dgst -sha256 zelda3.sfc
SHA256(zelda3.sfc)= 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
keaton [~/GitHub/zelda3/tables] $ python extract_resources.py 
Failed to load ROM data for extraction. Error: ROM with hash 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03 not supported. Expected 66871d66be19ad2c34c927d6b14cd8eb6fc3181965b6e517cb361f7316009cfb. Please verify your ROM is the NA 1.0 version.
```