### PR TITLE
Let Makefile handle assets extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,24 @@
-# adapted from original README.md:
-# `clang -I/usr/include/SDL2 -lSDL2 -O2 -ozelda3 *.c snes/*.c`
+TARGET_EXEC:=zelda3
+ROM:=tables/zelda3.sfc
+SRCS:=$(wildcard *.c snes/*.c)
+OBJS:=$(SRCS:%.c=%.o)
+GEN:=$(shell grep -hor tables/generated.*.h --include \*.c .)
+PYTHON:=/usr/bin/env python3
+CFLAGS:=${CFLAGS} $(shell sdl2-config --cflags)
+LDFLAGS:=${LDFLAGS} $(shell sdl2-config --libs)
 
-ifneq (,$(shell which clang))
-	CC = clang
-else ifneq (,$(shell which gcc))
-	CC = gcc
-endif
+.PHONY: all clean clean_obj clean_gen
 
-ifneq (,$(findstring clang,$(CC)))
-	LTO = -flto=thin
-else ifneq (,$(findstring gcc,$(CC)))
-	LTO = -flto=auto
-endif
+all: $(TARGET_EXEC)
+$(TARGET_EXEC): tables/generated_dialogue.h $(OBJS)
+	$(CC) $(OBJS) -o $@ $(LDFLAGS)
+$(GEN): tables/dialogue.txt
+	cd tables; $(PYTHON) compile_resources.py ../$(ROM)
+tables/dialogue.txt:
+	cd tables; $(PYTHON) extract_resources.py ../$(ROM)
 
-override CFLAGS := -O2 `sdl2-config --cflags` $(LTO) $(CXXFLAGS)
-override LDFLAGS := -lm `sdl2-config --libs` $(LDFLAGS)
-
-override OBJS = $(patsubst %.c,%.o,$(wildcard *.c snes/*.c))
-override BIN = zelda3
-
-.PHONY: all clean
-
-all: $(BIN)
-
-clean:
-	$(RM) $(BIN) $(OBJS)
-
-$(BIN): $(OBJS)
-	$(CC) $(CFLAGS) -o $(BIN) $(OBJS) $(LDFLAGS)
+clean: clean_obj clean_gen
+clean_obj:
+	$(RM) $(OBJS) $(TARGET_EXEC)
+clean_gen:
+	$(RM) $(GEN)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,20 @@ I got much assistance from spannierism's Zelda 3 JP disassembly and the other on
 
 ## Dependencies
 
-- the `libsdl2-dev` library (ubuntu: `apt install libsdl2-dev`, macOS: `brew install sdl2`). On Windows, it's installed automatically with NuGet.
-- a `tables/zelda3.sfc` US ROM file (for asset extraction step only) with SHA256 hash `66871d66be19ad2c34c927d6b14cd8eb6fc3181965b6e517cb361f7316009cfb`. 
-- The `pillow` and `pyyaml` python dependencies used by the assets extractor. `pip install pillow pyyaml`
+- the `libsdl2-dev` library
+  - Windows: automatically installed with NuGet
+  - Ubuntu: `apt install libsdl2-dev`
+  - macOS: `brew install sdl2`
+- a `tables/zelda3.sfc` US ROM file (for asset extraction step only)
+  - SHA256 : `66871d66be19ad2c34c927d6b14cd8eb6fc3181965b6e517cb361f7316009cfb`. 
+- The `pillow` and `pyyaml` python dependencies used by the assets extractor.
+  - `pip install pillow pyyaml`
 
 ## Compiling
+
+
+### Windows
+First extract and compile resources.
 
 `cd tables`
 
@@ -28,24 +37,25 @@ Run `python3 extract_resources.py` to extract resources from the ROM into a more
 
 Run `python3 compile_resources.py` to produce .h files that get included by the C code.
 
-
-### Windows
-First extract and compile resources, see above. Then build the .sln file with Visual Studio.
+Then build the .sln file with Visual Studio.
 
 ### Linux/macOS
-#### Dependencies
-Linux: `apt install libsdl2-dev`
 
-macOS: `brew install sdl2`
-
-#### Building
-First extract and compile resources, see above. Then make sure you are in the root directory.
-
+```sh
+make
 ```
-clang++ `sdl2-config --cflags` -O2 -ozelda3 *.c snes/*.c `sdl2-config --libs`
+<details>
+<summary>
+Advanced make usage ...
+</summary>
+
+```sh
+make -j$(nproc) # run on all core
+make clean all  # clear gen+obj and rebuild
+CC=clang make   # specify compiler
+CFLAGS=-O3 make # specify compilation flags
 ```
-or
-`make -j$(nproc)`
+</details>
 
 ## Usage and controls
 
@@ -77,13 +87,14 @@ Additionally, the following commands are available:
 | E   | Hard reset            |
 | P   | Pause                 |
 | T   | Toggle replay turbo   |
+| O   | Set dungeon key to 1  |
 | K   | Clear all input history from current snapshot  |
 | F1-F10 | Load snapshot      |
 | Alt+Enter | Toggle Fullscreen     |
 | Shift+F1-F10 | Save snapshot |
 | Ctrl+F1-F10 | Replay the snapshot |
-
-Additionally, there are a bunch of included playthrough snapshots that play all dungeons of the game. You access them with the digit keys. If you want to replay the stage in turbo mode, press Ctrl+Digit (eg Ctrl-5).
+| 1-9 | run a dungeons playthrough snapshots |
+| Ctrl+1-9 | run a dungeons playthrough in turbo mode |
 
 
 ## License


### PR DESCRIPTION
Tested on multiple Linux and on MacOS

Because of the CRLF convertion, the changes are unreadable with whitespace. Better use
https://github.com/snesrev/zelda3/pull/31/files?w=1