### PR TITLE
Clear existing framebuffer before rendering on Linux

### DIFF
--- a/main.c
+++ b/main.c
@@ -341,6 +341,7 @@ static void RenderScreen(SDL_Window *window, SDL_Renderer *renderer, SDL_Texture
   ppu_putPixels(GetPpuForRendering(), (uint8_t*) pixels);
   SDL_UnlockTexture(texture);
 
+  SDL_RenderClear(renderer);
   SDL_DisplayMode display_mode;
   if (fullscreen && SDL_GetWindowDisplayMode(window, &display_mode) == 0) {
     uint32 w = display_mode.w, h = display_mode.h;


### PR DESCRIPTION
I'm getting garbled background when running this game in fullscreen using ALT+ENTER on Linux:

![render_errors](https://user-images.githubusercontent.com/1417444/187995750-26c719aa-41a9-42a1-a1a1-81a5b5e882eb.png)

This usually happens because the previous framebuffer gets re-used with its old previous content. Clearing it before drawing solves this issue.