### PR TITLE
Fix permissions bits when creating saves/ directory

### DIFF
--- a/main.c
+++ b/main.c
@@ -190,7 +190,7 @@ int main(int argc, char** argv) {
 #if defined(_WIN32)
   _mkdir("saves");
 #else
-  mkdir("saves", 755);
+  mkdir("saves", 0755);
 #endif
 
   SetSnes(snes);


### PR DESCRIPTION
Currently, when the program is run from a directory without a `saves` directory, that directory will be created with options resulting in it being writable, but not readable (depending on user).

## Before
```
keaton [~/GitHub/zelda3] $ make
[make output]
keaton [~/GitHub/zelda3] $ mkdir new_dir
keaton [~/GitHub/zelda3] $ cd new_dir
keaton [~/GitHub/zelda3/new_dir] $ ../zelda3
2: PatchByte(0x64a, 0x1. 1): c1 01 06 4a 01 
^C [kill program]
keaton [~/GitHub/zelda3/new_dir] $ ls -lad saves
d-wxr----x  2 keaton  staff  64 Sep  5 08:45 saves
keaton [~/GitHub/zelda3/new_dir] $ ls -la saves
ls: saves: Permission denied
```

## After
```
keaton [~/GitHub/zelda3] $ make
cc -c -O2 -I/usr/local/include/SDL2 -D_THREAD_SAFE main.c -o main.o
[make output]
keaton [~/GitHub/zelda3] $ mkdir new_dir
keaton [~/GitHub/zelda3] $ cd new_dir
keaton [~/GitHub/zelda3/new_dir] $ ../zelda3
2: PatchByte(0x64a, 0x1. 1): c1 01 06 4a 01 
^C^C
^C [kill program]
keaton [~/GitHub/zelda3/new_dir] $ ls -lad saves
drwxr-xr-x  2 keaton  staff  64 Sep  5 08:47 saves // much better
keaton [~/GitHub/zelda3/new_dir] $ ls -la saves
total 0
drwxr-xr-x  2 keaton  staff  64 Sep  5 08:47 .
drwxr-xr-x  3 keaton  staff  96 Sep  5 08:47 ..
```