### PR TITLE
Rename title bar text to "The Legend of Zelda: A Link to the Past" with optional statistics

### DIFF
--- a/config.c
+++ b/config.c
@@ -212,6 +212,9 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
     } else if (StringEqualsNoCase(key, "IgnoreAspectRatio")) {
       g_config.ignore_aspect_ratio = atoi(value);
       return true;
+    } else if (StringEqualsNoCase(key, "DisplayPerfInTitle")) {
+      g_config.display_perf_title = atoi(value);
+      return true;
     }
 
   }

--- a/config.h
+++ b/config.h
@@ -36,6 +36,7 @@ typedef struct Config {
   bool enhanced_mode7;
   bool new_renderer;
   bool ignore_aspect_ratio;
+  bool display_perf_title;
 } Config;
 
 extern Config g_config;

--- a/main.c
+++ b/main.c
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
     printf("Failed to init SDL: %s\n", SDL_GetError());
     return 1;
   }
-  SDL_Window* window = SDL_CreateWindow("Zelda3", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, kRenderWidth, kRenderHeight, g_win_flags);
+  SDL_Window* window = SDL_CreateWindow("The Legend of Zelda: A Link to the Past", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, kRenderWidth, kRenderHeight, g_win_flags);
   if(window == NULL) {
     printf("Failed to create window: %s\n", SDL_GetError());
     return 1;

--- a/main.c
+++ b/main.c
@@ -127,7 +127,7 @@ enum {
 
 static bool RenderScreenWithPerf(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
   bool rv;
-  if (g_display_perf) {
+  if (g_display_perf || g_config.display_perf_title) {
     static float history[64], average;
     static int history_pos;
     uint64 before = SDL_GetPerformanceCounter();
@@ -390,8 +390,16 @@ static void RenderScreen(SDL_Window *window, SDL_Renderer *renderer, SDL_Texture
     return;
   }
   bool hq = RenderScreenWithPerf(pixels, pitch, g_ppu_render_flags);
-  if (g_display_perf)
+  if (g_display_perf) {
     RenderNumber(pixels + (pitch*2<<hq), pitch, g_curr_fps, hq);
+  }
+  if (g_config.display_perf_title) {
+    char title[48] = "The Legend of Zelda: A Link to the Past | FPS: ";
+    char fps[10];
+    sprintf(fps, "%d", g_curr_fps);
+    strncat(title, fps, 10);
+    SDL_SetWindowTitle(window, title);
+  }
   SDL_UnlockTexture(texture);
   SDL_RenderClear(renderer);
 

--- a/main.c
+++ b/main.c
@@ -394,10 +394,10 @@ static void RenderScreen(SDL_Window *window, SDL_Renderer *renderer, SDL_Texture
     RenderNumber(pixels + (pitch*2<<hq), pitch, g_curr_fps, hq);
   }
   if (g_config.display_perf_title) {
-    char title[48] = "The Legend of Zelda: A Link to the Past | FPS: ";
-    char fps[10];
-    sprintf(fps, "%d", g_curr_fps);
-    strncat(title, fps, 10);
+    char title[] = "The Legend of Zelda: A Link to the Past | FPS: ";
+    char curr_fps[11];
+    int curr_fps_size = sprintf(curr_fps, "%d", g_curr_fps);
+    strncat(title, curr_fps, curr_fps_size);
     SDL_SetWindowTitle(window, title);
   }
   SDL_UnlockTexture(texture);

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -2,6 +2,7 @@
 NewRenderer = 1
 EnhancedMode7 = 1
 IgnoreAspectRatio = 0
+DisplayPerfInTitle = 1
 
 
 [KeyMap]


### PR DESCRIPTION
Fixes issue #68 
Also adds an option to the config file to toggle displaying the FPS in the title bar