### PR TITLE
Show performance in title bar (toggleable in config file)

### DIFF
--- a/config.c
+++ b/config.c
@@ -238,6 +238,9 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
     if (StringEqualsNoCase(key, "Autosave")) {
       g_config.autosave = (bool)strtol(value, (char**)NULL, 10);
       return true;
+    } else if (StringEqualsNoCase(key, "DisplayPerfInTitle")) {
+      g_config.display_perf_title = (bool)strtol(value, (char**)NULL, 10);
+      return true;
     }
 
   }

--- a/config.h
+++ b/config.h
@@ -42,6 +42,7 @@ typedef struct Config {
   uint8 audio_channels;
   uint16 audio_samples;
   bool autosave;
+  bool display_perf_title;
 } Config;
 
 extern Config g_config;

--- a/main.c
+++ b/main.c
@@ -477,8 +477,8 @@ static void RenderScreen(SDL_Window *window, SDL_Renderer *renderer, SDL_Texture
     RenderNumber(pixels + (pitch * 2 << hq), pitch, g_curr_fps, hq);
   }
   if (g_config.display_perf_title) {
-    char title[] = "";
-    sprintf(title, "%s%s%d", kWindowTitle, " | FPS: ", g_curr_fps);
+    char title[60];
+    snprintf(title, 60, "%s%s%d", kWindowTitle, " | FPS: ", g_curr_fps);
     SDL_SetWindowTitle(window, title);
   }
   uint64 t2 = SDL_GetPerformanceCounter();

--- a/main.c
+++ b/main.c
@@ -130,7 +130,7 @@ static SDL_HitTestResult HitTestCallback(SDL_Window *win, const SDL_Point *area,
 
 static bool RenderScreenWithPerf(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
   bool rv;
-  if (g_display_perf) {
+  if (g_display_perf || g_config.display_perf_title) {
     static float history[64], average;
     static int history_pos;
     uint64 before = SDL_GetPerformanceCounter();
@@ -473,9 +473,14 @@ static void RenderScreen(SDL_Window *window, SDL_Renderer *renderer, SDL_Texture
   }
   uint64 t1 = SDL_GetPerformanceCounter();
   bool hq = RenderScreenWithPerf(pixels, pitch, g_ppu_render_flags);
-  if (g_display_perf)
-    RenderNumber(pixels + (pitch*2<<hq), pitch, g_curr_fps, hq);
-
+  if (g_display_perf) {
+    RenderNumber(pixels + (pitch * 2 << hq), pitch, g_curr_fps, hq);
+  }
+  if (g_config.display_perf_title) {
+    char title[] = "";
+    sprintf(title, "%s%s%d", kWindowTitle, " | FPS: ", g_curr_fps);
+    SDL_SetWindowTitle(window, title);
+  }
   uint64 t2 = SDL_GetPerformanceCounter();
   SDL_UnlockTexture(texture);
   uint64 t3 = SDL_GetPerformanceCounter();

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -1,6 +1,7 @@
 [General]
 # Automatically save state on quit and reload on start
 Autosave = 0
+DisplayPerfInTitle = 1
 
 
 [Graphics]


### PR DESCRIPTION
Reimplementation of PR #70 that doesn't hard crash in Windows 10 and uses sprintf instead of strncat (doh!) using the recently introduced kWindowTitle constant. Tested on Windows 10 and Manjaro Linux.