### PR TITLE
Fix "multi-character character constant" warning

### DIFF
--- a/zelda_rtl.c
+++ b/zelda_rtl.c
@@ -354,7 +354,7 @@ void ZeldaOpenMsuFile() {
   char buf[40], hdr[8];
   sprintf(buf, "msu/alttp_msu-%d.pcm", msu_track);
   msu_file = fopen(buf, "rb");
-  if (msu_file == NULL || fread(hdr, 1, 8, msu_file) != 8 || *(uint32 *)(hdr + 0) != '1USM') {
+  if (msu_file == NULL || fread(hdr, 1, 8, msu_file) != 8 || *(uint32 *)(hdr + 0) != (('1' << 24) | ('U' << 16) | ('S' << 8) | 'M')) {
     if (msu_file != NULL) fclose(msu_file), msu_file = NULL;
     zelda_apu_write(APUI00, msu_track);
     msu_track = 0;


### PR DESCRIPTION
Even though it's just a warning, from [my reading](https://zipcon.net/~swhite/docs/computers/languages/c_multi-char_const.html), it seems that the value is dependent on the implementation of the compiler and thus may produce different integers with different compilers.