### PR TITLE
add basic support for in-application volume adjustment (OS mixer or SDL mixer, depending on platform)

### DIFF
--- a/config.c
+++ b/config.c
@@ -56,7 +56,7 @@ static const KeyNameId kKeyNameId[] = {
   M(Controls), M(Load), M(Save), M(Replay), M(LoadRef), M(ReplayRef),
   S(CheatLife), S(CheatKeys), S(CheatEquipment), S(CheatWalkThroughWalls),
   S(ClearKeyLog), S(StopReplay), S(Fullscreen), S(Reset),
-  S(Pause), S(PauseDimmed), S(Turbo), S(ReplayTurbo), S(WindowBigger), S(WindowSmaller), S(DisplayPerf), S(ToggleRenderer),
+  S(Pause), S(PauseDimmed), S(Turbo), S(ReplayTurbo), S(WindowBigger), S(WindowSmaller), S(VolumeUp), S(VolumeDown), S(DisplayPerf), S(ToggleRenderer),
 };
 #undef S
 #undef M

--- a/config.h
+++ b/config.h
@@ -31,6 +31,8 @@ enum {
   kKeys_WindowSmaller,
   kKeys_DisplayPerf,
   kKeys_ToggleRenderer,
+  kKeys_VolumeUp,
+  kKeys_VolumeDown,
   kKeys_Total,
 };
 

--- a/main.c
+++ b/main.c
@@ -6,10 +6,18 @@
 #include <SDL.h>
 #ifdef _WIN32
 #include <direct.h>
+#define SYSTEM_VOLUME_MIXER_AVAILABLE
 #else
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#endif
+
+#ifdef SYSTEM_VOLUME_MIXER_AVAILABLE
+#define VOLUME_INCREMENT 5
+#include "platform/win32/volume_control.h"
+#else
+#define VOLUME_INCREMENT (SDL_MIX_MAXVOLUME >> 4)
 #endif
 
 #include "snes/ppu.h"
@@ -34,6 +42,7 @@ static void HandleInput(int keyCode, int modCode, bool pressed);
 static void HandleGamepadInput(int button, bool pressed);
 static void HandleGamepadAxisInput(int gamepad_id, int axis, int value);
 static void OpenOneGamepad(int i);
+static void HandleVolumeAdjustment(int volume_adjustment);
 static void LoadAssets();
 
 enum {
@@ -59,6 +68,7 @@ static int g_curr_fps;
 static int g_ppu_render_flags = 0;
 static bool g_run_without_emu = false;
 static int g_snes_width, g_snes_height;
+static int g_sdl_audio_mixer_volume = SDL_MIX_MAXVOLUME;
 
 void NORETURN Die(const char *error) {
   fprintf(stderr, "Error: %s\n", error);
@@ -177,7 +187,13 @@ static void SDLCALL AudioCallback(void *userdata, Uint8 *stream, int len) {
       g_audiobuffer_end = g_audiobuffer + g_frames_per_block * g_audio_channels * sizeof(int16);
     }
     int n = IntMin(len, g_audiobuffer_end - g_audiobuffer_cur);
+#ifdef SYSTEM_VOLUME_MIXER_AVAILABLE
     memcpy(stream, g_audiobuffer_cur, n);
+#else
+    // Ensure destination audio stream is empty/silence.
+    SDL_memset(stream, 0, n);
+    SDL_MixAudioFormat(stream, g_audiobuffer_cur, AUDIO_S16, n, g_sdl_audio_mixer_volume);
+#endif
     g_audiobuffer_cur += n;
     stream += n;
     len -= n;
@@ -558,6 +574,12 @@ static void HandleCommand(uint32 j, bool pressed) {
     case kKeys_WindowSmaller: ChangeWindowScale(-1); break;
     case kKeys_DisplayPerf: g_display_perf ^= 1; break;
     case kKeys_ToggleRenderer: g_ppu_render_flags ^= kPpuRenderFlags_NewRenderer; break;
+    case kKeys_VolumeUp:
+      HandleVolumeAdjustment(VOLUME_INCREMENT);
+      break;
+    case kKeys_VolumeDown:
+      HandleVolumeAdjustment(-VOLUME_INCREMENT);
+      break;
     default: assert(0);
     }
   }
@@ -592,6 +614,18 @@ static void HandleGamepadInput(int button, bool pressed) {
   case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: SetButtonState(10, pressed); break;
   case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: SetButtonState(11, pressed); break;
   }
+}
+
+static void HandleVolumeAdjustment(int volume_adjustment) {
+#ifdef SYSTEM_VOLUME_MIXER_AVAILABLE
+  int current_volume = GetApplicationVolume();
+  int new_volume = IntMin(IntMax(0, current_volume + volume_adjustment), 100);
+  SetApplicationVolume(new_volume);
+  printf("[System Volume]=%i\n", new_volume);
+#else
+  g_sdl_audio_mixer_volume = IntMin(IntMax(0, g_sdl_audio_mixer_volume + volume_adjustment), SDL_MIX_MAXVOLUME);
+  printf("[SDL mixer volume]=%i\n", g_sdl_audio_mixer_volume);
+#endif
 }
 
 // Approximates atan2(y, x) normalized to the [0,4) range

--- a/platform/win32/volume_control.c
+++ b/platform/win32/volume_control.c
@@ -22,6 +22,16 @@ static void InitializeCom() {
     com_initialized = SUCCEEDED(CoInitialize(NULL));
 }
 
+int GetApplicationVolume() {
+  ISimpleAudioVolume *simple_audio_volume = GetSimpleAudioVolume();
+  if (!simple_audio_volume)
+    return false;
+  float volume_level = -1;
+  HRESULT result = ISimpleAudioVolume_GetMasterVolume(simple_audio_volume, &volume_level);
+  ISimpleAudioVolume_Release(simple_audio_volume);
+  return (int)(volume_level * 100);
+}
+
 bool SetApplicationVolume(int volume_level) {
   ISimpleAudioVolume *simple_audio_volume = GetSimpleAudioVolume();
   if (!simple_audio_volume)

--- a/platform/win32/volume_control.h
+++ b/platform/win32/volume_control.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 
+int GetApplicationVolume();
 bool SetApplicationVolume(int volume_level);
 bool SetApplicationMuted(bool muted);
 

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -116,6 +116,9 @@ ReplayTurbo = t
 WindowBigger = Ctrl+Up
 WindowSmaller = Ctrl+Down
 
+VolumeUp = Shift+=
+VolumeDown = Shift+-
+
 Load =      F1,     F2,     F3,     F4,     F5,     F6,     F7,     F8,     F9,     F10
 Save = Shift+F1,Shift+F2,Shift+F3,Shift+F4,Shift+F5,Shift+F6,Shift+F7,Shift+F8,Shift+F9,Shift+F10
 Replay= Ctrl+F1,Ctrl+F2,Ctrl+F3,Ctrl+F4,Ctrl+F5,Ctrl+F6,Ctrl+F7,Ctrl+F8,Ctrl+F9,Ctrl+F10


### PR DESCRIPTION
### Description
Fixes #55

On Windows, the application will compile and call the `platform/win32/volume_control` functions that utilize [Win32 APIs](https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nn-audioclient-isimpleaudiovolume) for controlling the Sound mixer. On other platforms, these APIs are not available, so volume will be controlled via the SDL audio buffer, according to the [documentation ](https://wiki.libsdl.org/SDL_MixAudioFormat)for `SDL_MixAudioFormat`.

By default, volume controls are `<Shift>` + `-`/`=`.

### Will this Pull Request break anything? 
Tested both code paths on Windows.

### Suggested Testing Steps
Test on Windows and a non-Windows platform (or locally test compiling Windows with `#undef SYSTEM_VOLUME_MIXER_AVAILABLE`

### Demos
## Windows
https://user-images.githubusercontent.com/596193/193437340-dda772cc-89d0-4e11-afcc-c23d44e1f547.mp4

## macOS
https://user-images.githubusercontent.com/596193/193438127-2abecac0-5c64-4abe-bafd-80406a2c7a3d.mp4


