### PR TITLE
Add MSUVolume value to zelda3.ini

### DIFF
--- a/config.c
+++ b/config.c
@@ -262,6 +262,9 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
       return true;
     } else if (StringEqualsNoCase(key, "EnableMSU")) {
       return ParseBool(value, &g_config.enable_msu);
+    } else if (StringEqualsNoCase(key, "MSUVolume")) {
+      g_config.max_msu_volume = (uint8)strtol(value, (char**)NULL, 10);
+      return true;
     }
   } else if (section == 3) {
     if (StringEqualsNoCase(key, "Autosave")) {

--- a/config.h
+++ b/config.h
@@ -62,6 +62,7 @@ typedef struct Config {
   bool no_sprite_limits;
   bool display_perf_title;
   bool enable_msu;
+  uint8 max_msu_volume;
   bool disable_frame_delay;
   uint32 features0;
 

--- a/features.h
+++ b/features.h
@@ -53,6 +53,7 @@ enum {
 
 extern uint32 g_wanted_zelda_features;
 extern bool msu_enabled;
+extern uint8 msu_max_volume;
 
 
 #endif  // ZELDA3_FEATURES_H_

--- a/main.c
+++ b/main.c
@@ -313,6 +313,7 @@ int main(int argc, char** argv) {
                        g_config.extend_y * kPpuRenderFlags_Height240 |
                        g_config.no_sprite_limits * kPpuRenderFlags_NoSpriteLimits;
   msu_enabled = g_config.enable_msu;
+  msu_max_volume = g_config.max_msu_volume;
 
   if (g_config.fullscreen == 1)
     g_win_flags ^= SDL_WINDOW_FULLSCREEN_DESKTOP;

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -67,6 +67,8 @@ AudioSamples = 512
 # Enable MSU support for audio. Files need to be in a subfolder, msu/alttp_msu-*.pcm
 # Only works with 44100 hz and 2 channels
 EnableMSU = 0
+# Volume for MSU audio file playback (0-255)
+MSUVolume = 63
 
 
 [Features]

--- a/zelda_rtl.c
+++ b/zelda_rtl.c
@@ -918,6 +918,7 @@ void LoadSongBank(const uint8 *p) {  // 808888
 }
 
 bool msu_enabled;
+uint8 msu_max_volume;
 static FILE *msu_file;
 static uint32 msu_loop_start;
 static uint32 msu_buffer_size, msu_buffer_pos;
@@ -965,7 +966,7 @@ void ZeldaPlayMsuAudioTrack() {
   }
   if ((music_control & 0xf0) != 0xf0) {
     msu_track = music_control;
-    msu_volume = 255;
+    msu_volume = msu_max_volume;
     msu_curr_sample = 0;
     ZeldaOpenMsuFile();
   } else if (msu_file == NULL) {
@@ -982,9 +983,9 @@ void MixinMsuAudioData(int16 *audio_buffer, int audio_samples) {
     if (last_music_control == 0xf1)
       msu_volume = IntMax(msu_volume - 3, 0);
     else if (last_music_control == 0xf2)
-      msu_volume = IntMax(msu_volume - 3, 0x40);
+      msu_volume = IntMax(msu_volume - 3, IntMin(msu_max_volume, 0x40));
     else if (last_music_control == 0xf3)
-      msu_volume = IntMin(msu_volume + 3, 0xff);
+      msu_volume = IntMin(msu_volume + 3, IntMin(msu_max_volume, 0xff));
   }
   if (msu_volume == 0)
     return;


### PR DESCRIPTION
Note that just like with EnableMSU, when loading a save state, the MSUVolume value won't be used until the song changes.

I set the default to 63 (25%) which is still a bit louder than the equivalent SNES audio for the MSU files I'm using.