### PR TITLE
Update tcc and sdl to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Switching current item with L/R keys.
 5. Extract resources by typing `python extract_resources.py` and hit enter
 6. Compile the extracted resources by typing `python compile_resources.py` and hit enter
 7. Close the command prompt
-8. Download [TCC](https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip) and extract to the "\third_party" subfolder
-9. Download [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-VC.zip) and extract to the "\third_party" subfolder
+8. Download [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20221020/tcc_20221020.zip) and extract to the "\third_party" subfolder
+9. Download [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.24.1/SDL2-devel-2.24.1-VC.zip) and extract to the "\third_party" subfolder
 10. Double-click `run_with_tcc.bat` in the main dir to create `zelda3.exe` in that same dir
 11. Configure with `zelda3.ini` in the main dir
 

--- a/run_with_tcc.bat
+++ b/run_with_tcc.bat
@@ -1,11 +1,11 @@
 @echo off
 
-set SDL2=third_party\SDL2-2.24.0
+set SDL2=third_party\SDL2-2.24.1
 
 IF NOT EXIST "third_party\tcc\tcc.exe" (
   ECHO:
   ECHO ERROR: third_party\tcc\tcc.exe doesn't exist. Please verify that you have put it in the right location.
-  ECHO   Download it from http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip
+  ECHO   Download it from https://github.com/FitzRoyX/tinycc/releases/download/tcc_20221020/tcc_20221020.zip
   ECHO   It needs to be the 64-bit version.
   ECHO:
   PAUSE
@@ -17,7 +17,7 @@ IF NOT EXIST "third_party\tcc\tcc.exe" (
 IF NOT EXIST "%SDL2%\lib\x64\SDL2.dll" (
   ECHO:
   ECHO ERROR: SDL is not unzipped properly into %SDL2%
-  ECHO   Download it from https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-VC.zip
+  ECHO   Download it from https://github.com/libsdl-org/SDL/releases/download/release-2.24.1/SDL2-devel-2.24.1-VC.zip
   ECHO:
   PAUSE
   EXIT /B 1


### PR DESCRIPTION
Updated links to newer versions of tcc and sdl2. Old tcc was 5 years old and had a compiler bug that affected bee behavior. Unfortunately, this puts my name in the links. If this is a problem, make another tcc fork.