### PR TITLE
fix cape doesnt drain while grabbing or pulling (#126)

### DIFF
--- a/player.c
+++ b/player.c
@@ -2124,10 +2124,6 @@ void Link_APress_PerformBasic(uint8 action_x2) {  // 879c5f
   default:
     assert(0);
   }
-
-  // Zelda vanilla bug: Disallow dragging while in cape mode, it uses no magic.
-  if (link_cape_mode && enhanced_features0 & kFeatures0_MiscBugFixes)
-    link_grabbing_wall = 0;
 }
 
 void HandleSwordSfxAndBeam() {  // 879c66
@@ -3284,7 +3280,8 @@ void HaltLinkWhenUsingItems() {  // 87ae65
 }
 
 void Link_HandleCape_passive_LiftCheck() {  // 87ae88
-  if (link_state_bits & 0x80)
+  //bugfix: grabbing or pulling while wearing cape didn't drain magic
+  if (link_state_bits & 0x80 || (enhanced_features0 & kFeatures0_MiscBugFixes && link_grabbing_wall))
     Player_CheckHandleCapeStuff();
 }
 


### PR DESCRIPTION
replaces the old bugfix with this new one that doesn't take the ability away