### PR TITLE
Fix OpenGL ES support.

### DIFF
--- a/glsl_shader.c
+++ b/glsl_shader.c
@@ -214,7 +214,12 @@ void GlslShader_ReadShaderFile(GlslShader *gs, const char *filename, ByteArray *
 
 static bool GlslPass_Compile(GlslPass *p, uint type, const uint8 *data, size_t size) {
   static const char kVertexPrefix[] =   "#define VERTEX\n#define PARAMETER_UNIFORM\n";
+#ifndef USE_GLES
   static const char kFragmentPrefix[] = "#define FRAGMENT\n#define PARAMETER_UNIFORM\n";
+#else
+  static const char kFragmentPrefix[] = "#define FRAGMENT\n#define PARAMETER_UNIFORM\n" \
+					"precision mediump float;";
+#endif
   const GLchar *strings[3];
   GLint lengths[3];
   char buffer[256];
@@ -222,8 +227,13 @@ static bool GlslPass_Compile(GlslPass *p, uint type, const uint8 *data, size_t s
   size_t skip = 0;
 
   if (size < 8 || memcmp(data, "#version", 8) != 0) {
+#ifndef USE_GLES
     strings[0] = "#version 330\n";
     lengths[0] = sizeof("#version 330\n") - 1;
+#else
+    strings[0] = "#version 300 es\n";
+    lengths[0] = sizeof("#version 300 es\n") - 1;
+#endif
   } else {
     while (skip < size && data[skip++] != '\n') {}
     strings[0] = (char*)data;


### PR DESCRIPTION
### Description
This PR lets the game to be built in GLES mode, so it can run in OpenGL mode even if only OpenGL ES 3.0 is available.
This is useful for Raspberry Pi and other ARM SBCs where OpenGL 3.3 is not available but GLES 3.x is, which is enough for this game and it's shaders.  
Shaders are essential in this game, as it was designed to look as it does on a CRT, so bringing up GLES brings the shaders and makes the game look "as expected".

Also, GL context version is now checked via SDL2 API calls, using `SDL_GL_GetAttribute()`, since previous method using `ParseVersionFromString()` from third_party/gl_core/gl_core_3_1.c  doesn't work with GLES version strings. 
That's because `ParseVersionFromString()` uses `atoi()` which doesn't work with GLES version strings since they start with letters instead of numbers: a typical OpenGL version string is "4.5 (Core Profile) Mesa 22.0.5" while a GLES version string looks like  "OpenGL ES 3.2 Mesa 22.0.5", which confuses `atoi()`.

### Will this Pull Request break anything? 
No.

### Suggested Testing Steps
Build with `CFLAGS="-DUSE_GLES=1" make` and run the game.