### PR TITLE
Fix 4:3 aspect ratio and add 8:7.

### DIFF
--- a/config.c
+++ b/config.c
@@ -416,9 +416,13 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
           g_config.extended_aspect_ratio = (h * 16 / 10 - 256) / 2;
         else if (strcmp(s, "18:9") == 0)
           g_config.extended_aspect_ratio = (h * 18 / 9 - 256) / 2;
-        else if (strcmp(s, "4:3") == 0)
+        else if (strcmp(s, "8:7") == 0)
           g_config.extended_aspect_ratio = 0;
-        else if (strcmp(s, "unchanged_sprites") == 0)
+        else if (strcmp(s, "4:3") == 0) {
+          g_config.extended_aspect_ratio = 0;
+          g_config.tv_aspect_ratio = true;
+	}
+	else if (strcmp(s, "unchanged_sprites") == 0)
           nospr = true;
         else if (strcmp(s, "no_visual_fixes") == 0)
           novis = true;

--- a/config.h
+++ b/config.h
@@ -49,6 +49,7 @@ typedef struct Config {
   bool enhanced_mode7;
   bool new_renderer;
   bool ignore_aspect_ratio;
+  bool tv_aspect_ratio;
   uint8 fullscreen;
   uint8 window_scale;
   bool enable_audio;

--- a/main.c
+++ b/main.c
@@ -230,8 +230,12 @@ static bool SdlRenderer_Init(SDL_Window *window) {
     printf("\n");
   }
   g_renderer = renderer;
-  if (!g_config.ignore_aspect_ratio)
-    SDL_RenderSetLogicalSize(renderer, g_snes_width, g_snes_height);
+  if (!g_config.ignore_aspect_ratio) {
+    if(!g_config.tv_aspect_ratio)
+      SDL_RenderSetLogicalSize(renderer, g_snes_width, g_snes_height);
+    else
+      SDL_RenderSetLogicalSize(renderer, 4, 3);
+  }
   if (g_config.linear_filtering)
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "best");
 

--- a/opengl.c
+++ b/opengl.c
@@ -168,9 +168,15 @@ static void OpenGLRenderer_EndDraw() {
 
   if (!g_config.ignore_aspect_ratio) {
     if (viewport_width * g_draw_height < viewport_height * g_draw_width)
-      viewport_height = viewport_width * g_draw_height / g_draw_width;  // limit height
+      if (!g_config.tv_aspect_ratio)
+        viewport_height = viewport_width * g_draw_height / g_draw_width;  // limit height
+      else
+        viewport_height = viewport_width * 3 / 4;                         // limit height
     else
-      viewport_width = viewport_height * g_draw_width / g_draw_height;  // limit width
+      if (!g_config.tv_aspect_ratio)
+        viewport_width = viewport_height * g_draw_width / g_draw_height;  // limit width
+      else
+        viewport_width = viewport_height * 4 / 3;                         // limit width
   }
 
   int viewport_x = (drawable_width - viewport_width) >> 1;

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -3,7 +3,9 @@
 Autosave = 0
 DisplayPerfInTitle = 0
 
-# Extended aspect ratio, either 16:9, 16:10, or 18:9. 4:3 means normal aspect ratio.
+# Extended aspect ratio, either 16:9, 16:10, or 18:9. 4:3 means the aspect ratio that
+# the game would display on a real CRT TV, and 8:7 is the aspect ratio the game was
+# internally rendered at, before being ouput to TV, since SNES is 256x224 internally.
 # Add ", unchanged_sprites" to avoid changing sprite spawn/die behavior. Without this
 # replays will be incompatible.
 # Add ", no_visual_fixes" to avoid fixing some graphics glitches (for example with Cape).


### PR DESCRIPTION
### Description
On the SNES, Zelda ALTTP is rendered internally at 256x224, which is an 8:7 resolution, not 4:3.
However, when output to TV, the game is stretched to 4:3 by the SNES hardware. That's true for every SNES game running at 256x224.

So the game looks better at 4:3 as it looks on a real SNES on a real TV. At 8:7, everything is too "thin".

What this does is make 4:3 really 4:3 (graphics are slightly stretched by OpenGL/SDL2, as in the SNES), and add a 8:7 ratio that matches the internal resolution. This 8:7 ratio is what was previously called 4:3 (that was wrong, because 256x224 is not 4:3 by any means).

### Will this Pull Request break anything? 
No.

### Suggested Testing Steps
Run the game at 4:3 and run it at 8:7 (both can be set on the zelda3.ini file) and compare.

This is simple but somewhat important stuff so the game looks as intended, IMHO.