### PR TITLE
Switch Makefile Fix

### DIFF
--- a/platform/switch/Makefile
+++ b/platform/switch/Makefile
@@ -209,7 +209,15 @@ $(OUTPUT).elf	:	$(OFILES)
 
 $(OFILES_SRC)	: $(HFILES_BIN)
 
+#---------------------------------------------------------------------------------
+# devkitPro's rules are expecting the .o and .c files to be in the same directory,
+# but this Makefile will be run from within a build directory. This rule will run
+# instead of the built-in one and compile the .c files that are in the source
+# directory and put the resulting .o and .d files in the platform/switch/bin
+# directory.
+# --------------------------------------------------------------------------------
 %.o : $(SRC_DIR)/%.c
+#---------------------------------------------------------------------------------
 	$(SILENTMSG) $(notdir $<)
 	$(SILENTCMD)$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d $(CFLAGS) -c $< -o $@ $(ERROR_FILTER)
 

--- a/platform/switch/Makefile
+++ b/platform/switch/Makefile
@@ -209,6 +209,10 @@ $(OUTPUT).elf	:	$(OFILES)
 
 $(OFILES_SRC)	: $(HFILES_BIN)
 
+%.o : $(SRC_DIR)/%.c
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d $(CFLAGS) -c $< -o $@ $(ERROR_FILTER)
+
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
This PR fixes build errors that were occurring when attempting to build the switch makefile due to it ending up with the wrong paths to the Object files it needed to link. The end result is that instead of the `.o` and `.d` files being in the same directory as the source code, they will be in `platform/switch/bin`. From what I could gather that was the intended result anyway, but that wasn't happening, at least for me. 

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
This should not break anything (in fact it fixed switch builds).

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
The .nacp and .nro files are properly created, running `make clean` from `platform/switch` does still properly remove build artifacts, and the .nro does run correctly on the Switch.
