### PR TITLE
Add nix reproducible build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,38 @@ Same Steps 1-7 above<br/>
 10. Choose "build > build Zelda3" in the menu to create `zelda3.exe` in the "/bin/release" subfolder<br/>
 11. Configure with `zelda3.ini` in the main dir<br/>
 
+## Compiling on Linux with Nix
+1. Open a terminal
+2. Clone the repo and `cd` into it
+```sh
+git clone https://github.com/snesrev/zelda3
+cd zelda3
+```
+3. Place your US ROM file named `zelda3.sfc` in `zelda3/tables`
+4. Enter the nix shell environment
+```sh
+nix-shell
+```
+5. Compile
+```sh
+make
+```
+6. Running the executable with the proper graphics driver
+```sh
+nixGL ./zelda3
+```
+<details>
+<summary>
+Advanced make usage ...
+</summary>
+
+```sh
+make -j$(nproc) # run on all core
+make clean all  # clear gen+obj and rebuild
+CC=clang make   # specify compiler
+```
+</details>
+
 ## Installing libraries on Linux/MacOS
 1. Open a terminal
 2. Install pip if not already installed

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+with (import <nixpkgs> {});
+
+let
+	nixgl = import (builtins.fetchTarball https://github.com/guibou/nixGL/archive/main.tar.gz) {};
+	my-py-pkgs = py-pkgs: with py-pkgs; [
+		pillow
+		pyyaml
+	];
+	py-packaged = python3.withPackages my-py-pkgs;
+in
+mkShell {
+	buildInputs = [
+		py-packaged
+		SDL2
+		SDL2.dev
+		clang
+		nixgl.auto.nixGLDefault
+	];
+}


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
This request seeks to add a build environment using the nix package manager to ensure reproducible building environments (on Linux for sure, but maybe MacOS and WSL2 with X11 forwarding)

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
This request does not affect any of the preexisting compilation steps. It just adds a new compilation workflow option.

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
Nix can be obtained from [Nix's Website](https://nixos.org/download.html). After obtaining Nix (on Linux), following the new build instructions for Nix should be sufficient to build the application then run it with the proper graphics driver using `nixGL ./zelda3`