### PR TITLE
Added hotkey start & select exit

### DIFF
--- a/main.c
+++ b/main.c
@@ -414,6 +414,12 @@ int main(int argc, char** argv) {
         int b = RemapSdlButton(event.cbutton.button);
         if (b >= 0)
           HandleGamepadInput(b, event.type == SDL_CONTROLLERBUTTONDOWN);
+          
+          // Check for start and select buttons pressed and if so exit game
+        SDL_GameController* controller = SDL_GameControllerFromInstanceID(event.cbutton.which);
+        if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_START) && SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_BACK)) {
+            running = false;
+        }
         break;
       }
       case SDL_MOUSEWHEEL:


### PR DESCRIPTION
Added a start & select hotkey that stops the main loop and closes the game. The start & select exit is the standard function for users on RetroPie, Lakka and Batocera. It also allows the game to be played and closed without a keyboard.

### Description
<!-- What is the purpose of this PR and what it adds? -->

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
