### PR TITLE
Add option for 3D Zelda style quick spin attack

### DIFF
--- a/config.c
+++ b/config.c
@@ -475,6 +475,8 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
       return ParseBoolBit(value, &g_config.features0, kFeatures0_GameChangingBugFixes);
     } else if (StringEqualsNoCase(key, "CancelBirdTravel")) {
       return ParseBoolBit(value, &g_config.features0, kFeatures0_CancelBirdTravel);
+    } else if (StringEqualsNoCase(key, "QuickSpin")) {
+      return ParseBoolBit(value, &g_config.features0, kFeatures0_QuickSpin);
     }
   }
   return false;

--- a/features.h
+++ b/features.h
@@ -46,6 +46,8 @@ enum {
   kFeatures0_SwitchLRLimit = 32768,
 
   kFeatures0_DimFlashes = 65536,
+  
+  kFeatures0_QuickSpin = 262144,
 };
 
 #define enhanced_features0 (*(uint32*)(g_ram+0x64c))
@@ -56,6 +58,11 @@ enum {
 #define hud_cur_item_x (*(uint8*)(g_ram+0x656))
 #define hud_cur_item_l (*(uint8*)(g_ram+0x657))
 #define hud_cur_item_r (*(uint8*)(g_ram+0x658))
+#define quickspin_timer_up (*(uint8*)(g_ram+0x659))
+#define quickspin_timer_down (*(uint8*)(g_ram+0x65a))
+#define quickspin_timer_left (*(uint8*)(g_ram+0x65b))
+#define quickspin_timer_right (*(uint8*)(g_ram+0x65c))
+#define quickspin_is_ready (*(bool*)(g_ram+0x65d))
 
 
 

--- a/features.h
+++ b/features.h
@@ -58,11 +58,11 @@ enum {
 #define hud_cur_item_x (*(uint8*)(g_ram+0x656))
 #define hud_cur_item_l (*(uint8*)(g_ram+0x657))
 #define hud_cur_item_r (*(uint8*)(g_ram+0x658))
-#define quickspin_timer_up (*(uint8*)(g_ram+0x659))
-#define quickspin_timer_down (*(uint8*)(g_ram+0x65a))
-#define quickspin_timer_left (*(uint8*)(g_ram+0x65b))
-#define quickspin_timer_right (*(uint8*)(g_ram+0x65c))
-#define quickspin_is_ready (*(bool*)(g_ram+0x65d))
+#define qs_up (*(uint8*)(g_ram+0x659))
+#define qs_down (*(uint8*)(g_ram+0x65a))
+#define qs_left (*(uint8*)(g_ram+0x65b))
+#define qs_right (*(uint8*)(g_ram+0x65c))
+#define qs_ready (*(bool*)(g_ram+0x65d))
 
 
 

--- a/features.h
+++ b/features.h
@@ -47,7 +47,7 @@ enum {
 
   kFeatures0_DimFlashes = 65536,
   
-  kFeatures0_QuickSpin = 262144,
+  kFeatures0_QuickSpin = 131072,
 };
 
 #define enhanced_features0 (*(uint32*)(g_ram+0x64c))

--- a/player.c
+++ b/player.c
@@ -1970,7 +1970,6 @@ void Link_HandleSwordCooldown() {  // 879ac2
   } else {
     HandleSwordControls();
   }
-  quickspin_is_ready = false;
 
 }
 
@@ -2168,9 +2167,13 @@ void Link_CheckForSwordSwing() {  // 879cd9
         return;
     }
 	
-	if(quickspin_is_ready){
+	if(qs_ready){
 	  Link_ResetSwordAndItemUsage();
       Link_ActivateSpinAttack();
+	  qs_up = 0;
+	  qs_down = 0;
+	  qs_left = 0;
+	  qs_right = 0;
 	  //fprintf(stderr,"performed quickspin\n");
 	} else {
 	  
@@ -5773,6 +5776,7 @@ void Link_HandleVelocity() {  // 87e245
   }
   
   //----------- QUICK SPIN --------------
+  qs_ready = false;
   
   // convert velocity to signed ints
   int velx = link_actual_vel_x;
@@ -5787,45 +5791,84 @@ void Link_HandleVelocity() {  // 87e245
   
   //check for directions
   
-  uint8 quickspin_timer_duration = 24;
+  uint8 qs_duration = 24;
   
   if(vely < 0){
-	quickspin_timer_up = quickspin_timer_duration;
+	qs_up = qs_duration;
   }
   if(vely > 0){
-	quickspin_timer_down = quickspin_timer_duration;
+	qs_down = qs_duration;
   }
   if(velx < 0){
-	quickspin_timer_left = quickspin_timer_duration;
+	qs_left = qs_duration;
   }
   if(velx > 0){
-	quickspin_timer_right = quickspin_timer_duration;
+	qs_right = qs_duration;
   }
   
   //decrement timers
   
-  uint8 quickspin_timer_count = 0;
+  uint8 qs_count = 0;
   
-  if(quickspin_timer_up > 0){
-    quickspin_timer_up--;
-	quickspin_timer_count++;
+  if(qs_up > 0){
+    qs_up--;
+	qs_count++;
   }
-    if(quickspin_timer_down > 0){
-    quickspin_timer_down--;
-	quickspin_timer_count++;
+  if(qs_down > 0){
+    qs_down--;
+	qs_count++;
   }
-    if(quickspin_timer_left > 0){
-    quickspin_timer_left--;
-	quickspin_timer_count++;
+  if(qs_left > 0){
+    qs_left--;
+	qs_count++;
   }
-    if(quickspin_timer_right > 0){
-    quickspin_timer_right--;
-	quickspin_timer_count++;
+  if(qs_right > 0){
+    qs_right--;
+	qs_count++;
   }
-  //fprintf(stderr, "U: %d | D: %d | L: %d | R: %d | T: %d |\n", quickspin_timer_up,quickspin_timer_down,quickspin_timer_left,quickspin_timer_right, quickspin_timer_count);
-  if(quickspin_timer_count == 4){
+  //fprintf(stderr, "U: %d | D: %d | L: %d | R: %d | T: %d |\n", qs_up,qs_down,qs_left,qs_right, qs_count);
+
+  
+  
+  if(qs_count == 4){
+	//CLOCKWISE
+    //U -> L
+    if(qs_up < qs_right && qs_right < qs_down && qs_down < qs_left){
+	  qs_ready = true;
+	}
+	// R -> U
+	if(qs_right < qs_down && qs_down < qs_left && qs_left < qs_up){
+	  qs_ready = true;
+	}
+	// D -> R
+	if(qs_down < qs_left && qs_left < qs_up && qs_up < qs_right){
+	  qs_ready = true;
+	}
+	// L -> D
+	if(qs_left < qs_up && qs_up < qs_right && qs_right < qs_down){
+	  qs_ready = true;
+	}
+	
+	//COUNTERCLOCKWISE
+    //U -> R
+    if(qs_up < qs_left && qs_left < qs_down && qs_down < qs_right){
+	  qs_ready = true;
+	}
+	// L -> U
+	if(qs_left < qs_down && qs_down < qs_right && qs_right < qs_up){
+	  qs_ready = true;
+	}
+	// D -> L
+	if(qs_down < qs_right && qs_right <= qs_up && qs_up < qs_left){
+	  qs_ready = true;
+	}
+	// R -> D
+	if(qs_right < qs_up && qs_up < qs_left && qs_left < qs_down){
+	  qs_ready = true;
+	}
+	
 	//fprintf(stderr, "Can quickspin!\n");
-	quickspin_is_ready = true;
+	//quickspin_is_ready = true;
 	//Link_ActivateSpinAttack();
   }
   

--- a/player.c
+++ b/player.c
@@ -2167,14 +2167,13 @@ void Link_CheckForSwordSwing() {  // 879cd9
         return;
     }
 	
-	if(qs_ready){
+	if((enhanced_features0 & kFeatures0_QuickSpin) && qs_ready){
 	  Link_ResetSwordAndItemUsage();
       Link_ActivateSpinAttack();
 	  qs_up = 0;
 	  qs_down = 0;
 	  qs_left = 0;
 	  qs_right = 0;
-	  //fprintf(stderr,"performed quickspin\n");
 	} else {
 	  
 	
@@ -5775,105 +5774,90 @@ void Link_HandleVelocity() {  // 87e245
     link_actual_vel_y = (link_direction & 8) ? -vel : vel;
   }
   
-  //----------- QUICK SPIN --------------
-  qs_ready = false;
   
-  // convert velocity to signed ints
-  int velx = link_actual_vel_x;
-  int vely = link_actual_vel_y;
-  if(velx >= 127){
-    velx -= 256;
-  }
-  if(vely >= 127){
-    vely -= 256;
-  }
-  //fprintf(stderr, "x: %d y: %d\n",velx,vely);
-  
-  //check for directions
-  
-  uint8 qs_duration = 24;
-  
-  if(vely < 0){
-	qs_up = qs_duration;
-  }
-  if(vely > 0){
-	qs_down = qs_duration;
-  }
-  if(velx < 0){
-	qs_left = qs_duration;
-  }
-  if(velx > 0){
-	qs_right = qs_duration;
-  }
-  
-  //decrement timers
-  
-  uint8 qs_count = 0;
-  
-  if(qs_up > 0){
-    qs_up--;
-	qs_count++;
-  }
-  if(qs_down > 0){
-    qs_down--;
-	qs_count++;
-  }
-  if(qs_left > 0){
-    qs_left--;
-	qs_count++;
-  }
-  if(qs_right > 0){
-    qs_right--;
-	qs_count++;
-  }
-  //fprintf(stderr, "U: %d | D: %d | L: %d | R: %d | T: %d |\n", qs_up,qs_down,qs_left,qs_right, qs_count);
+  if(enhanced_features0 & kFeatures0_QuickSpin){
+    //----------- QUICK SPIN --------------
+    qs_ready = false;
 
-  
-  
-  if(qs_count == 4){
-	//CLOCKWISE
-    //U -> L
-    if(qs_up < qs_right && qs_right < qs_down && qs_down < qs_left){
-	  qs_ready = true;
-	}
-	// R -> U
-	if(qs_right < qs_down && qs_down < qs_left && qs_left < qs_up){
-	  qs_ready = true;
-	}
-	// D -> R
-	if(qs_down < qs_left && qs_left < qs_up && qs_up < qs_right){
-	  qs_ready = true;
-	}
-	// L -> D
-	if(qs_left < qs_up && qs_up < qs_right && qs_right < qs_down){
-	  qs_ready = true;
-	}
-	
-	//COUNTERCLOCKWISE
-    //U -> R
-    if(qs_up < qs_left && qs_left < qs_down && qs_down < qs_right){
-	  qs_ready = true;
-	}
-	// L -> U
-	if(qs_left < qs_down && qs_down < qs_right && qs_right < qs_up){
-	  qs_ready = true;
-	}
-	// D -> L
-	if(qs_down < qs_right && qs_right <= qs_up && qs_up < qs_left){
-	  qs_ready = true;
-	}
-	// R -> D
-	if(qs_right < qs_up && qs_up < qs_left && qs_left < qs_down){
-	  qs_ready = true;
-	}
-	
-	//fprintf(stderr, "Can quickspin!\n");
-	//quickspin_is_ready = true;
-	//Link_ActivateSpinAttack();
+    // convert velocity to signed ints
+    int velx = link_actual_vel_x;
+    int vely = link_actual_vel_y;
+    if(velx >= 127)
+    velx -= 256;
+    if(vely >= 127)
+    vely -= 256;
+    //fprintf(stderr, "x: %d y: %d\n",velx,vely);
+
+    //check for directions
+    uint8 qs_duration = 24;
+
+    if(vely < 0){
+    qs_up = qs_duration;
+    }
+    if(vely > 0){
+    qs_down = qs_duration;
+    }
+    if(velx < 0){
+    qs_left = qs_duration;
+    }
+    if(velx > 0){
+    qs_right = qs_duration;
+    }
+
+    //decrement timers
+
+    uint8 qs_count = 0;
+
+    if(qs_up > 0){
+    qs_up--;
+    qs_count++;
+    }
+    if(qs_down > 0){
+    qs_down--;
+    qs_count++;
+    }
+    if(qs_left > 0){
+    qs_left--;
+    qs_count++;
+    }
+    if(qs_right > 0){
+    qs_right--;
+    qs_count++;
+    }
+    //fprintf(stderr, "U: %d | D: %d | L: %d | R: %d | T: %d |\n", qs_up,qs_down,qs_left,qs_right, qs_count);
+
+
+
+    if(qs_count == 4){
+      // CLOCKWISE
+      // U -> L
+      if(qs_up < qs_right && qs_right < qs_down && qs_down < qs_left)
+        qs_ready = true;
+      // R -> U
+      else if(qs_right < qs_down && qs_down < qs_left && qs_left < qs_up)
+        qs_ready = true;
+      // D -> R
+      else if(qs_down < qs_left && qs_left < qs_up && qs_up < qs_right)
+        qs_ready = true;
+      // L -> D
+      else if(qs_left < qs_up && qs_up < qs_right && qs_right < qs_down)
+        qs_ready = true;
+
+      // COUNTERCLOCKWISE
+      // U -> R
+      else if(qs_up < qs_left && qs_left < qs_down && qs_down < qs_right)
+        qs_ready = true;
+      // L -> U
+      else if(qs_left < qs_down && qs_down < qs_right && qs_right < qs_up)
+        qs_ready = true;
+      // D -> L
+      else if(qs_down < qs_right && qs_right <= qs_up && qs_up < qs_left)
+        qs_ready = true;
+      // R -> D
+      else if(qs_right < qs_up && qs_up < qs_left && qs_left < qs_down)
+        qs_ready = true;
+    }
   }
-  
-  
-  //-------------- END QUICKSPIN -------------------
   link_actual_vel_z = 0xff;
   link_z_coord = 0xffff;
   link_subpixel_z = 0;

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -137,6 +137,9 @@ GameChangingBugFixes = 0
 # Allow bird travel to be cancelled by hitting the X key
 CancelBirdTravel = 0
 
+# Allow 3D Zelda style quick spin attack
+QuickSpin = 1
+
 
 [KeyMap]
 # Change what keyboard keys map to the joypad
@@ -173,8 +176,8 @@ Save = Shift+F1,Shift+F2,Shift+F3,Shift+F4,Shift+F5,Shift+F6,Shift+F7,Shift+F8,S
 Replay= Ctrl+F1,Ctrl+F2,Ctrl+F3,Ctrl+F4,Ctrl+F5,Ctrl+F6,Ctrl+F7,Ctrl+F8,Ctrl+F9,Ctrl+F10
 
 # Uncomment this to allow loading of reference saves
-#LoadRef = 1,2,3,4,5,6,7,8,9,0,-,=,Backspace
-#ReplayRef = Ctrl+1,Ctrl+2,Ctrl+3,Ctrl+4,Ctrl+5,Ctrl+6,Ctrl+7,Ctrl+8,Ctrl+9,Ctrl+0,Ctrl+-,Ctrl+=,Ctrl+Backspace
+LoadRef = 1,2,3,4,5,6,7,8,9,0,-,=,Backspace
+ReplayRef = Ctrl+1,Ctrl+2,Ctrl+3,Ctrl+4,Ctrl+5,Ctrl+6,Ctrl+7,Ctrl+8,Ctrl+9,Ctrl+0,Ctrl+-,Ctrl+=,Ctrl+Backspace
 
 [GamepadMap]
 # Any keys used in KeyMap can be used also in this section.

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -176,8 +176,8 @@ Save = Shift+F1,Shift+F2,Shift+F3,Shift+F4,Shift+F5,Shift+F6,Shift+F7,Shift+F8,S
 Replay= Ctrl+F1,Ctrl+F2,Ctrl+F3,Ctrl+F4,Ctrl+F5,Ctrl+F6,Ctrl+F7,Ctrl+F8,Ctrl+F9,Ctrl+F10
 
 # Uncomment this to allow loading of reference saves
-LoadRef = 1,2,3,4,5,6,7,8,9,0,-,=,Backspace
-ReplayRef = Ctrl+1,Ctrl+2,Ctrl+3,Ctrl+4,Ctrl+5,Ctrl+6,Ctrl+7,Ctrl+8,Ctrl+9,Ctrl+0,Ctrl+-,Ctrl+=,Ctrl+Backspace
+# LoadRef = 1,2,3,4,5,6,7,8,9,0,-,=,Backspace
+# ReplayRef = Ctrl+1,Ctrl+2,Ctrl+3,Ctrl+4,Ctrl+5,Ctrl+6,Ctrl+7,Ctrl+8,Ctrl+9,Ctrl+0,Ctrl+-,Ctrl+=,Ctrl+Backspace
 
 [GamepadMap]
 # Any keys used in KeyMap can be used also in this section.

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -137,8 +137,8 @@ GameChangingBugFixes = 0
 # Allow bird travel to be cancelled by hitting the X key
 CancelBirdTravel = 0
 
-# Allow 3D Zelda style quick spin attack
-QuickSpin = 1
+# Allow 3D Zelda style quick spin attack by doing a spin then using sword
+QuickSpin = 0
 
 
 [KeyMap]


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
This PR adds an option to zelda3.ini for quick spin attacks, which are performed by spinning 360 degrees in any direction and swinging the sword. 
Video showcase: https://www.youtube.com/watch?v=2S8YxZUAcXE
### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
It compiles and runs fine for me, so probably not?

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
1. Enable QuickSpin in zelda3.ini
2. Load a reference state where Link has the sword, and perform a quick spin atack
3. Close the game and disable QuickSpin in zelda3.ini
4. Load a reference state where Link has the sword, and notice that the quick spin attack is no longer possible