### PR TITLE
Add shell.nix for easy building anywhere Nix is available

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages; 
+      [ gcc 
+        clang 
+        SDL2.dev 
+        gnumake 
+        (python311.withPackages(ps: with ps; [ pillow pyyaml ]))
+      ];
+
+   # To build, make sure you have the ROM in place, then run `make -j16`
+}


### PR DESCRIPTION
### Description
This PR adds a `shell.nix` file that can be used by typing `nix-shell` on any system that has Nix installed, including MacOS and Linux (Though I can't test it on MacOS.) It pulls in all the dependencies (except the rom) and drops you into a shell where you can simply type `make` and it'll produce a binary.

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
No

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
Install Nix on your system, type `nix-shell` and then `make -j{core count}`