### PR TITLE
Fixed bug on cursor for copy file screen

### DIFF
--- a/src/select_file.c
+++ b/src/select_file.c
@@ -459,15 +459,14 @@ void CopyFile_SelectionAndBlinker() {  // 8cd13f
     uint8 k = selectfile_R16;
     if (a & 8) {
       do {
-        if (--k < 0) {
+        if (sign8(--k)) {
           k = 3;
           break;
         }
       } while (!selectfile_arr1[k]);
     } else {
       do {
-        k++;
-        if (k >= 4)
+        if (++k >= 4)
           k = 0;
       } while (k != 3 && !selectfile_arr1[k]);
     }


### PR DESCRIPTION
Fixed bug cursor would continue to move past top file after pressing up.

### Description
<!-- What is the purpose of this PR and what it adds? -->
This PR fixes a very tiny bug unique to this implementation. The fairy cursor on the copy file screen would continue to move up past the top file and jump to various places on the screen. Function originally attempted to check if an unsigned byte was less than zero. Fixed by instead just checking if the signed bit is set.

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
No.

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
Move cursor around on the copy file screen.
