### PR TITLE
Fixes window size on monitors with DPI scaling enabled

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #ifdef _WIN32
 #include "platform/win32/volume_control.h"
 #include <direct.h>
+#include <Windows.h>
 #else
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -305,6 +306,11 @@ int main(int argc, char** argv) {
                        g_config.no_sprite_limits * kPpuRenderFlags_NoSpriteLimits;
   ZeldaEnableMsu(g_config.enable_msu);
   ZeldaSetLanguage(g_config.language);
+  
+#ifdef _WIN32
+  SetProcessDPIAware();
+#endif
+
 
   if (g_config.fullscreen == 1)
     g_win_flags ^= SDL_WINDOW_FULLSCREEN_DESKTOP;


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
On monitors with DPI scaling enabled, the window launches at the incorrect scale (overdrawing onto other monitors & being zoomed in);
![2025-04-23_16-35-25-explorer-Program_Manager](https://github.com/user-attachments/assets/9ba97b5f-e8d7-4289-8887-92f02d4deee5)

flagging the application as high DPI aware, it now launches at the proper scale independent of DPI magnification setting.
![2025-04-23_16-34-42-explorer-Program_Manager](https://github.com/user-attachments/assets/a2d11286-ddde-426b-8629-5b4e41e46edf)


### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
Nope! It's a quick and easy one line fix. :)
