### PR TITLE
[WIP] Ultrawide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ __pycache__
 /sprites-gfx
 /glsl-shaders
 /token.txt
+/.agent-shell/

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = [
+    pkgs.gnumake
+    pkgs.pkg-config
+  ];
+
+  buildInputs = [
+    pkgs.SDL2
+    pkgs.libGL
+    (pkgs.python3.withPackages (ps: [
+      ps.pillow
+      ps.pyyaml
+    ]))
+  ];
+
+  # Project uses pre-C23 empty parameter lists; GCC 15 defaults to C23
+  CFLAGS = "-O2 -Werror -std=gnu17";
+}

--- a/snes/ppu.c
+++ b/snes/ppu.c
@@ -693,8 +693,18 @@ void PpuSetMode7PerspectiveCorrection(Ppu *ppu, int low, int high) {
 }
 
 void PpuSetExtraSideSpace(Ppu *ppu, int left, int right, int bottom) {
-  ppu->extraLeftCur = UintMin(left, ppu->extraLeftRight);
-  ppu->extraRightCur = UintMin(right, ppu->extraLeftRight);
+  left = UintMin(left, ppu->extraLeftRight);
+  right = UintMin(right, ppu->extraLeftRight);
+  // Tilemap is 512px wide, viewport is 256px, so max 256px of extra space total.
+  // Beyond this the tilemap wraps and shows tiles from the wrong side.
+  enum { kMaxTotalExtra = 256 };
+  if (left + right > kMaxTotalExtra) {
+    int total = left + right;
+    left = left * kMaxTotalExtra / total;
+    right = kMaxTotalExtra - left;
+  }
+  ppu->extraLeftCur = left;
+  ppu->extraRightCur = right;
   ppu->extraBottomCur = UintMin(bottom, 16);
 }
 

--- a/snes/ppu.c
+++ b/snes/ppu.c
@@ -288,10 +288,19 @@ static void PpuDrawBackground_4bpp(Ppu *ppu, uint y, bool sub, uint layer, PpuZb
   int sc_offs = bglayer->tilemapAdr + (((y >> 3) & 0x1f) << 5);
   if ((y & 0x100) && bglayer->tilemapHigher)
     sc_offs += bglayer->tilemapWider ? 0x800 : 0x400;
-  const uint16 *tps[2] = {
-    &ppu->vram[sc_offs & 0x7fff],
-    &ppu->vram[sc_offs + (bglayer->tilemapWider ? 0x400 : 0) & 0x7fff]
-  };
+  const uint16 *tps[4];
+  tps[0] = &ppu->vram[sc_offs & 0x7fff];
+  tps[1] = &ppu->vram[(sc_offs + (bglayer->tilemapWider ? 0x400 : 0)) & 0x7fff];
+  if (ppu->extTilemapEnabled && bglayer->tilemapWider) {
+    int ext_offs = ((y >> 3) & 0x1f) << 5;
+    if ((y & 0x100) && bglayer->tilemapHigher)
+      ext_offs += 0x800;
+    tps[2] = &ppu->extTilemap[ext_offs];
+    tps[3] = &ppu->extTilemap[ext_offs + 0x400];
+  } else {
+    tps[2] = tps[0];
+    tps[3] = tps[1];
+  }
   int tileadr = ppu->bgLayer[layer].tileAdr, pixel;
   int tileadr1 = tileadr + 7 - (y & 0x7), tileadr0 = tileadr + (y & 0x7);
   const uint16 *addr;
@@ -301,10 +310,10 @@ static void PpuDrawBackground_4bpp(Ppu *ppu, uint y, bool sub, uint layer, PpuZb
     uint x = win.edges[windex] + bglayer->hScroll;
     uint w = win.edges[windex + 1] - win.edges[windex];
     PpuZbufType *dstz = ppu->bgBuffers[sub].data + win.edges[windex] + kPpuExtraLeftRight;
-    const uint16 *tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
-    const uint16 *tp_last = tps[x >> 8 & 1] + 31;
-    const uint16 *tp_next = tps[(x >> 8 & 1) ^ 1];
-#define NEXT_TP() if (tp != tp_last) tp += 1; else tp = tp_next, tp_next = tp_last - 31, tp_last = tp + 31;
+    int tp_idx = (x >> 8) & 1;  // Always start in VRAM (pages 0-1); ext pages reached by cycling
+    const uint16 *tp = tps[tp_idx] + ((x >> 3) & 0x1f);
+    const uint16 *tp_last = tps[tp_idx] + 31;
+#define NEXT_TP() if (tp != tp_last) tp += 1; else { tp_idx = (tp_idx + 1) & 3; tp = tps[tp_idx]; tp_last = tp + 31; }
     // Handle clipped pixels on left side
     if (x & 7) {
       int curw = IntMin(8 - (x & 7), w);
@@ -362,6 +371,7 @@ static void PpuDrawBackground_4bpp(Ppu *ppu, uint y, bool sub, uint layer, PpuZb
       }
     }
   }
+#undef NEXT_TP
 #undef READ_BITS
 #undef DO_PIXEL
 #undef DO_PIXEL_HFLIP
@@ -695,13 +705,23 @@ void PpuSetMode7PerspectiveCorrection(Ppu *ppu, int low, int high) {
 void PpuSetExtraSideSpace(Ppu *ppu, int left, int right, int bottom) {
   left = UintMin(left, ppu->extraLeftRight);
   right = UintMin(right, ppu->extraLeftRight);
-  // Tilemap is 512px wide, viewport is 256px, so max 256px of extra space total.
-  // Beyond this the tilemap wraps and shows tiles from the wrong side.
-  enum { kMaxTotalExtra = 256 };
-  if (left + right > kMaxTotalExtra) {
-    int total = left + right;
-    left = left * kMaxTotalExtra / total;
-    right = kMaxTotalExtra - left;
+  // When extTilemapEnabled, the game fills both VRAM and extTilemap each frame
+  // with correct tile data, so the viewport can safely exceed the 512px tilemap.
+  // Without extTilemap, clamp to what the tilemap ring buffer can support.
+  if (!ppu->extTilemapEnabled) {
+    int tilemap_extra = 0;
+    for (int i = 0; i < 2; i++)
+      if (ppu->bgLayer[i].tilemapWider)
+        tilemap_extra = IntMax(tilemap_extra, 128);
+    if (left + right > tilemap_extra) {
+      if (tilemap_extra <= 0) {
+        left = right = 0;
+      } else {
+        int total = left + right;
+        left = left * tilemap_extra / total;
+        right = tilemap_extra - left;
+      }
+    }
   }
   ppu->extraLeftCur = left;
   ppu->extraRightCur = right;
@@ -1134,10 +1154,28 @@ static int ppu_getPixelForBgLayer(Ppu *ppu, int x, int y, int layer, bool priori
   int tileHighBitX = wideTiles ? 0x200 : 0x100;
   int tileBitsY = 3;
   int tileHighBitY = 0x100;
-  uint16_t tilemapAdr = layerp->tilemapAdr + (((y >> tileBitsY) & 0x1f) << 5 | ((x >> tileBitsX) & 0x1f));
-  if ((x & tileHighBitX) && layerp->tilemapWider) tilemapAdr += 0x400;
-  if ((y & tileHighBitY) && layerp->tilemapHigher) tilemapAdr += layerp->tilemapWider ? 0x800 : 0x400;
-  uint16_t tile = ppu->vram[tilemapAdr & 0x7fff];
+  // Check if this pixel is in the extended tilemap range (>512px from viewport start).
+  // The normal tilemap is 64 tile columns (512px) and wraps. The extended tilemap
+  // provides additional columns for viewports wider than 512px.
+  uint16_t tile;
+  bool use_ext = false;
+  if (ppu->extTilemapEnabled && layerp->tilemapWider) {
+    int vp_left = layerp->hScroll - (layer != 2 ? ppu->extraLeftCur : 0);
+    int dist = (x - vp_left) & 0x3ff;  // distance from viewport left, mod 1024
+    use_ext = (dist >= 512);
+  }
+  if (use_ext) {
+    // Extended tilemap: map x into the ext pages (0x000 and 0x400)
+    int ext_offs = (((y >> tileBitsY) & 0x1f) << 5) | ((x >> tileBitsX) & 0x1f);
+    if ((x >> tileBitsX) & 0x20) ext_offs += 0x400;
+    if ((y & tileHighBitY) && layerp->tilemapHigher) ext_offs += 0x800;
+    tile = ppu->extTilemap[ext_offs & 0xfff];
+  } else {
+    uint16_t tilemapAdr = layerp->tilemapAdr + (((y >> tileBitsY) & 0x1f) << 5 | ((x >> tileBitsX) & 0x1f));
+    if ((x & tileHighBitX) && layerp->tilemapWider) tilemapAdr += 0x400;
+    if ((y & tileHighBitY) && layerp->tilemapHigher) tilemapAdr += layerp->tilemapWider ? 0x800 : 0x400;
+    tile = ppu->vram[tilemapAdr & 0x7fff];
+  }
   // check priority, get palette
   if (((bool)(tile & 0x2000)) != priority) return 0; // wrong priority
   int paletteNum = (tile & 0x1c00) >> 10;

--- a/snes/ppu.h
+++ b/snes/ppu.h
@@ -126,6 +126,12 @@ struct Ppu {
   PpuPixelPrioBufs bgBuffers[2];
   PpuPixelPrioBufs objBuffer;
   uint16_t vram[0x8000];
+  // Extended tilemap for widescreen viewports > 512px.
+  // Holds 4 pages (0x400 words each) for tile columns 64-127.
+  // Filled by the game each frame; the PPU renderer reads from here
+  // when the viewport wraps past the normal 64-column tilemap.
+  uint16_t extTilemap[0x1000];
+  bool extTilemapEnabled;
 };
 
 Ppu* ppu_init();

--- a/snes/ppu.h
+++ b/snes/ppu.h
@@ -52,7 +52,8 @@ struct Ppu {
   uint8_t renderFlags;
   uint32_t renderPitch;
   uint8_t *renderBuffer;
-  uint8_t extraLeftCur, extraRightCur, extraLeftRight, extraBottomCur;
+  uint16_t extraLeftCur, extraRightCur, extraLeftRight;
+  uint8_t extraBottomCur;
   float mode7PerspectiveLow, mode7PerspectiveHigh;
 
   // TMW / TSW etc

--- a/src/config.c
+++ b/src/config.c
@@ -358,7 +358,7 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
       return true;
     } else if (StringEqualsNoCase(key, "OutputMethod")) {
       g_config.output_method = StringEqualsNoCase(value, "SDL-Software") ? kOutputMethod_SDLSoftware :
-                               StringEqualsNoCase(value, "OpenGL") ? kOutputMethod_OpenGL : 
+                               StringEqualsNoCase(value, "OpenGL") ? kOutputMethod_OpenGL :
                                StringEqualsNoCase(value, "OpenGL ES") ? kOutputMethod_OpenGL_ES :
                                                                         kOutputMethod_SDL;
       return true;
@@ -394,7 +394,7 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
         g_config.enable_msu = kMsuEnabled_MsuDeluxe;
       else if (StringEqualsNoCase(value, "deluxe-opuz"))
         g_config.enable_msu = kMsuEnabled_MsuDeluxe | kMsuEnabled_Opuz;
-      else 
+      else
         return ParseBool(value, (bool*)&g_config.enable_msu);
       return true;
     } else if (StringEqualsNoCase(key, "MSUPath")) {
@@ -424,6 +424,8 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
           g_config.extended_aspect_ratio = (h * 16 / 10 - 256) / 2;
         else if (strcmp(s, "18:9") == 0)
           g_config.extended_aspect_ratio = (h * 18 / 9 - 256) / 2;
+        else if (strcmp(s, "32:9") == 0)
+          g_config.extended_aspect_ratio = (h * 32 / 9 - 256) / 2;
         else if (strcmp(s, "4:3") == 0)
           g_config.extended_aspect_ratio = 0;
         else if (strcmp(s, "unchanged_sprites") == 0)
@@ -484,7 +486,7 @@ static bool ParseOneConfigFile(const char *filename, int depth) {
   char *filedata = (char*)ReadWholeFile(filename, NULL), *p;
   if (!filedata)
     return false;
-  
+
   int section = -2;
   g_config.memory_buffer = filedata;
 

--- a/src/config.h
+++ b/src/config.h
@@ -59,7 +59,7 @@ typedef struct Config {
   uint8 audio_channels;
   uint16 audio_samples;
   bool autosave;
-  uint8 extended_aspect_ratio;
+  uint16 extended_aspect_ratio;
   bool extend_y;
   bool no_sprite_limits;
   bool display_perf_title;

--- a/src/main.c
+++ b/src/main.c
@@ -296,6 +296,8 @@ int main(int argc, char** argv) {
   g_snes_height = (g_config.extend_y ? 240 : 224);
 
 
+
+
   // Delay actually setting those features in ram until any snapshots finish playing.
   g_wanted_zelda_features = g_config.features0;
 

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -2410,15 +2410,18 @@ uint16 *BufferAndBuildMap16Stripes_X(uint16 *dst) {  // 82f3b9
   return dst;
 }
 
-// Fill extended tilemap with correct tile data for overflow columns beyond
-// the 512px SNES tilemap. Does NOT touch VRAM (ring buffer handles that).
+// Fill VRAM and extended tilemap with correct tile data for the widescreen
+// viewport. Writes to ALL visible tile columns:
+//   - VRAM pages 0-1: overwrites stale ring buffer data
+//   - ExtTilemap pages 2-3: fills overflow beyond 512px
 //
-// Key: PPU scroll registers are 10-bit (0-1023) but the overworld uses full
-// coordinates (e.g., 1024+). We use BG2HOFS_copy2/BG1HOFS_copy2 (full game
-// scroll) for map data lookup, and the PPU register for renderer page walk.
+// Two coordinate systems are used:
+//   - PPU register scroll (10-bit wrapped): for VRAM/ext addresses and page walk
+//     (must match renderer exactly)
+//   - Full game scroll (BG1/2HOFS_copy2): for map data lookup in dung_bg1/bg2
 //
 // The old renderer cycles 4 pages: start -> +1 -> +2 -> +3 (mod 4).
-// Pages 0-1 are VRAM (ring buffer), pages 2-3 are extTilemap.
+// Pages 0-1 are VRAM, pages 2-3 are extTilemap.
 void Overworld_FillExtTilemap(struct Ppu *ppu) {
   int extra_left = ppu->extraLeftCur;
   int extra_right = ppu->extraRightCur;
@@ -2427,10 +2430,6 @@ void Overworld_FillExtTilemap(struct Ppu *ppu) {
     return;
 
   int total_vp = 256 + extra_left + extra_right;
-  if (total_vp <= 512) {
-    ppu->extTilemapEnabled = false;
-    return;
-  }
 
   bool is_big = !kOverworldMapIsSmall[BYTE(overworld_screen_index) & 0x3f];
   int map_cols = is_big ? 64 : 32;
@@ -2455,11 +2454,6 @@ void Overworld_FillExtTilemap(struct Ppu *ppu) {
               dbg_counter / 60, extra_left, extra_right, total_vp,
               (int)BYTE(overworld_screen_index),
               is_big ? " (big)" : " (small)", area_x, area_y);
-      fprintf(f, "  BG1: game=(%d,%d) ppu=(%d,%d) BG2: game=(%d,%d) ppu=(%d,%d)\n",
-              game_hscroll[0], game_vscroll[0],
-              ppu->bgLayer[0].hScroll, ppu->bgLayer[0].vScroll,
-              game_hscroll[1], game_vscroll[1],
-              ppu->bgLayer[1].hScroll, ppu->bgLayer[1].vScroll);
       fclose(f);
     }
   }
@@ -2469,71 +2463,66 @@ void Overworld_FillExtTilemap(struct Ppu *ppu) {
     if (!bglayer->tilemapWider)
       continue;
     const uint16 *bg_src = bg_sources[layer];
+    uint16 tilemap_base = bglayer->tilemapAdr;
 
-    // Use PPU register (unsigned) for renderer page walk — must match renderer exactly
-    uint32_t rx_start = (uint32_t)((int)bglayer->hScroll - extra_left);
+    // PPU register scroll (unsigned, 10-bit) — for renderer page walk and tilemap addressing
+    uint32_t ppu_hscroll = bglayer->hScroll;
+    uint32_t ppu_vscroll = bglayer->vScroll;
+
+    // Renderer starting position (must match renderer's uint arithmetic)
+    uint32_t rx_start = (uint32_t)(ppu_hscroll - extra_left);
     int start_page = (rx_start >> 8) & 1;
     int start_pos = (rx_start >> 3) & 0x1f;
 
-    // Use full game scroll for map data lookup
-    int gx_start = game_hscroll[layer] - extra_left;  // leftmost visible pixel (full coords)
-    int gy_top = game_vscroll[layer];                  // topmost visible pixel
+    // Full game scroll for map data lookup
+    int gx_start = game_hscroll[layer] - extra_left;
+    int gy_top = game_vscroll[layer];
 
-    // How many tile columns until we leave VRAM pages and enter extTilemap?
-    // From start position: remainder of first VRAM page + full second VRAM page
-    int vram_cols = (32 - start_pos) + 32;
-
-    // Total tile columns in viewport
     int num_tc = (total_vp + 7) / 8 + 1;
+    int tr_count = (223 + ppu->extraBottomCur) / 8 + 2;
 
     int cur_page = start_page;
     int pos_in_page = start_pos;
 
-    if (dbg) {
-      FILE *f = fopen("debug.log", "a");
-      if (f) {
-        int local_x = gx_start - area_x;
-        fprintf(f, "  Layer %d: rx_start=0x%x start_page=%d start_pos=%d vram_cols=%d\n",
-                layer, rx_start, start_page, start_pos, vram_cols);
-        fprintf(f, "    gx_start=%d local_x=%d local_tc=%d map_col=%d\n",
-                gx_start, local_x, local_x >> 3, local_x >> 4);
-        fclose(f);
-      }
-    }
-
-    int tr_count = (223 + ppu->extraBottomCur) / 8 + 2;
-
     for (int col_idx = 0; col_idx < num_tc; col_idx++) {
-      // Skip VRAM columns — ring buffer handles those
-      if (cur_page >= 2) {
-        // Map data: use full game coordinates
-        int game_x = gx_start + col_idx * 8;
-        int local_x = game_x - area_x;
-        int map_col = local_x >> 4;   // Map16 column (16px per cell)
-        int sub_x = (local_x >> 3) & 1;
+      // Map data: use full game coordinates
+      int game_x = gx_start + col_idx * 8;
+      int local_x = game_x - area_x;
+      int map_col = local_x >> 4;
+      int sub_x = (local_x >> 3) & 1;
 
-        for (int row_idx = 0; row_idx < tr_count; row_idx++) {
-          int game_y = gy_top + row_idx * 8;
-          int local_y = game_y - area_y;
-          int map_row = local_y >> 4;   // Map16 row
-          int sub_y = (local_y >> 3) & 1;
+      for (int row_idx = 0; row_idx < tr_count; row_idx++) {
+        // Map data lookup: full game coordinates
+        int game_y = gy_top + row_idx * 8;
+        int local_y = game_y - area_y;
+        int map_row = local_y >> 4;
+        int sub_y = (local_y >> 3) & 1;
 
-          uint16 map16_val = 0;
-          if (map_col >= 0 && map_col < map_cols && map_row >= 0 && map_row < map_rows)
-            map16_val = bg_src[map_row * 64 + map_col];
+        uint16 map16_val = 0;
+        if (map_col >= 0 && map_col < map_cols && map_row >= 0 && map_row < map_rows)
+          map16_val = bg_src[map_row * 64 + map_col];
 
-          uint16 tile_entry = map8[map16_val * 4 + sub_y * 2 + sub_x];
+        uint16 tile_entry = map8[map16_val * 4 + sub_y * 2 + sub_x];
 
-          // ExtTilemap address: same layout as VRAM tilemap pages
-          int tr = game_y >> 3;
-          int y_page = (((tr >> 5) & 1) && bglayer->tilemapHigher) ? 0x800 : 0;
+        // Tilemap address: use PPU register scroll (must match renderer)
+        uint32_t renderer_y = ppu_vscroll + row_idx * 8;
+        int tr = renderer_y >> 3;
+        int y_page = (((tr >> 5) & 1) && bglayer->tilemapHigher) ? 0x800 : 0;
+        int row_in_page = (tr & 0x1f) * 32;
+
+        if (cur_page < 2) {
+          // VRAM page 0 or 1
+          int x_page = (cur_page == 1) ? 0x400 : 0;
+          int vram_addr = tilemap_base + y_page + x_page + row_in_page + pos_in_page;
+          ppu->vram[vram_addr & 0x7fff] = tile_entry;
+        } else {
+          // ExtTilemap page 2 or 3
           int x_page = (cur_page == 3) ? 0x400 : 0;
-          int ext_addr = y_page + x_page + (tr & 0x1f) * 32 + pos_in_page;
+          int ext_addr = y_page + x_page + row_in_page + pos_in_page;
           ppu->extTilemap[ext_addr & 0xfff] = tile_entry;
         }
       }
 
-      // Advance page walk
       pos_in_page++;
       if (pos_in_page >= 32) {
         pos_in_page = 0;
@@ -2542,7 +2531,7 @@ void Overworld_FillExtTilemap(struct Ppu *ppu) {
     }
   }
 
-  ppu->extTilemapEnabled = true;
+  ppu->extTilemapEnabled = (total_vp > 512);
 }
 
 uint16 *BufferAndBuildMap16Stripes_Y(uint16 *dst) {  // 82f482

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1,4 +1,5 @@
 #include "overworld.h"
+#include "snes/ppu.h"
 #include "hud.h"
 #include "load_gfx.h"
 #include "dungeon.h"
@@ -2407,6 +2408,141 @@ uint16 *BufferAndBuildMap16Stripes_X(uint16 *dst) {  // 82f3b9
     dst += 33;
   }
   return dst;
+}
+
+// Fill extended tilemap with correct tile data for overflow columns beyond
+// the 512px SNES tilemap. Does NOT touch VRAM (ring buffer handles that).
+//
+// Key: PPU scroll registers are 10-bit (0-1023) but the overworld uses full
+// coordinates (e.g., 1024+). We use BG2HOFS_copy2/BG1HOFS_copy2 (full game
+// scroll) for map data lookup, and the PPU register for renderer page walk.
+//
+// The old renderer cycles 4 pages: start -> +1 -> +2 -> +3 (mod 4).
+// Pages 0-1 are VRAM (ring buffer), pages 2-3 are extTilemap.
+void Overworld_FillExtTilemap(struct Ppu *ppu) {
+  int extra_left = ppu->extraLeftCur;
+  int extra_right = ppu->extraRightCur;
+
+  if (extra_left == 0 && extra_right == 0)
+    return;
+
+  int total_vp = 256 + extra_left + extra_right;
+  if (total_vp <= 512) {
+    ppu->extTilemapEnabled = false;
+    return;
+  }
+
+  bool is_big = !kOverworldMapIsSmall[BYTE(overworld_screen_index) & 0x3f];
+  int map_cols = is_big ? 64 : 32;
+  int map_rows = is_big ? 64 : 32;
+
+  const uint16 *map8 = GetMap16toMap8Table();
+
+  // Full game-level scroll positions (not 10-bit wrapped)
+  int game_hscroll[2] = { (int)BG1HOFS_copy2, (int)BG2HOFS_copy2 };
+  int game_vscroll[2] = { (int)BG1VOFS_copy2, (int)BG2VOFS_copy2 };
+  int area_x = ow_scroll_vars0.xstart;
+  int area_y = ow_scroll_vars0.ystart;
+
+  const uint16 *bg_sources[2] = { dung_bg1, dung_bg2 };
+
+  static int dbg_counter = 0;
+  bool dbg = ((dbg_counter++ % 60) == 0);
+  if (dbg) {
+    FILE *f = fopen("debug.log", "a");
+    if (f) {
+      fprintf(f, "[ExtTilemap] frame=%d extraL=%d extraR=%d vp=%dpx area=%d%s origin=(%d,%d)\n",
+              dbg_counter / 60, extra_left, extra_right, total_vp,
+              (int)BYTE(overworld_screen_index),
+              is_big ? " (big)" : " (small)", area_x, area_y);
+      fprintf(f, "  BG1: game=(%d,%d) ppu=(%d,%d) BG2: game=(%d,%d) ppu=(%d,%d)\n",
+              game_hscroll[0], game_vscroll[0],
+              ppu->bgLayer[0].hScroll, ppu->bgLayer[0].vScroll,
+              game_hscroll[1], game_vscroll[1],
+              ppu->bgLayer[1].hScroll, ppu->bgLayer[1].vScroll);
+      fclose(f);
+    }
+  }
+
+  for (int layer = 0; layer < 2; layer++) {
+    BgLayer *bglayer = &ppu->bgLayer[layer];
+    if (!bglayer->tilemapWider)
+      continue;
+    const uint16 *bg_src = bg_sources[layer];
+
+    // Use PPU register (unsigned) for renderer page walk — must match renderer exactly
+    uint32_t rx_start = (uint32_t)((int)bglayer->hScroll - extra_left);
+    int start_page = (rx_start >> 8) & 1;
+    int start_pos = (rx_start >> 3) & 0x1f;
+
+    // Use full game scroll for map data lookup
+    int gx_start = game_hscroll[layer] - extra_left;  // leftmost visible pixel (full coords)
+    int gy_top = game_vscroll[layer];                  // topmost visible pixel
+
+    // How many tile columns until we leave VRAM pages and enter extTilemap?
+    // From start position: remainder of first VRAM page + full second VRAM page
+    int vram_cols = (32 - start_pos) + 32;
+
+    // Total tile columns in viewport
+    int num_tc = (total_vp + 7) / 8 + 1;
+
+    int cur_page = start_page;
+    int pos_in_page = start_pos;
+
+    if (dbg) {
+      FILE *f = fopen("debug.log", "a");
+      if (f) {
+        int local_x = gx_start - area_x;
+        fprintf(f, "  Layer %d: rx_start=0x%x start_page=%d start_pos=%d vram_cols=%d\n",
+                layer, rx_start, start_page, start_pos, vram_cols);
+        fprintf(f, "    gx_start=%d local_x=%d local_tc=%d map_col=%d\n",
+                gx_start, local_x, local_x >> 3, local_x >> 4);
+        fclose(f);
+      }
+    }
+
+    int tr_count = (223 + ppu->extraBottomCur) / 8 + 2;
+
+    for (int col_idx = 0; col_idx < num_tc; col_idx++) {
+      // Skip VRAM columns — ring buffer handles those
+      if (cur_page >= 2) {
+        // Map data: use full game coordinates
+        int game_x = gx_start + col_idx * 8;
+        int local_x = game_x - area_x;
+        int map_col = local_x >> 4;   // Map16 column (16px per cell)
+        int sub_x = (local_x >> 3) & 1;
+
+        for (int row_idx = 0; row_idx < tr_count; row_idx++) {
+          int game_y = gy_top + row_idx * 8;
+          int local_y = game_y - area_y;
+          int map_row = local_y >> 4;   // Map16 row
+          int sub_y = (local_y >> 3) & 1;
+
+          uint16 map16_val = 0;
+          if (map_col >= 0 && map_col < map_cols && map_row >= 0 && map_row < map_rows)
+            map16_val = bg_src[map_row * 64 + map_col];
+
+          uint16 tile_entry = map8[map16_val * 4 + sub_y * 2 + sub_x];
+
+          // ExtTilemap address: same layout as VRAM tilemap pages
+          int tr = game_y >> 3;
+          int y_page = (((tr >> 5) & 1) && bglayer->tilemapHigher) ? 0x800 : 0;
+          int x_page = (cur_page == 3) ? 0x400 : 0;
+          int ext_addr = y_page + x_page + (tr & 0x1f) * 32 + pos_in_page;
+          ppu->extTilemap[ext_addr & 0xfff] = tile_entry;
+        }
+      }
+
+      // Advance page walk
+      pos_in_page++;
+      if (pos_in_page >= 32) {
+        pos_in_page = 0;
+        cur_page = (cur_page + 1) & 3;
+      }
+    }
+  }
+
+  ppu->extTilemapEnabled = true;
 }
 
 uint16 *BufferAndBuildMap16Stripes_Y(uint16 *dst) {  // 82f482

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -115,6 +115,7 @@ uint16 *BuildFullStripeDuringTransition_South(uint16 *dst);
 uint16 *BuildFullStripeDuringTransition_West(uint16 *dst);
 uint16 *BuildFullStripeDuringTransition_East(uint16 *dst);
 void OverworldHandleMapScroll();
+void Overworld_FillExtTilemap(struct Ppu *ppu);
 uint16 *CheckForNewlyLoadedMapAreas_North(uint16 *dst);
 uint16 *CheckForNewlyLoadedMapAreas_South(uint16 *dst);
 uint16 *CheckForNewlyLoadedMapAreas_West(uint16 *dst);

--- a/src/types.h
+++ b/src/types.h
@@ -9,7 +9,7 @@
 enum {
   kEnableLargeScreen = 1,
   // How much extra spacing to add on the sides
-  kPpuExtraLeftRight = kEnableLargeScreen ? 96 : 0,
+  kPpuExtraLeftRight = kEnableLargeScreen ? 320 : 0,
 };
 
 typedef uint8_t uint8;

--- a/src/zelda_rtl.c
+++ b/src/zelda_rtl.c
@@ -197,12 +197,18 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
 
   // Enable extended tilemap before the clamp check so PpuSetExtraSideSpace
   // bypasses the tilemap_extra cap when we're on the overworld.
-  // Only during stable gameplay (submodule 0 = player control), not transitions.
+  // Allow during: module 9 submodule 0 (player control), or module 14 with
+  // saved module 9 (dialog/sign overlay — overworld data still valid).
+  // Block during: overworld transitions (mod 9, submodule != 0) where map
+  // data and scroll values are in flux.
   {
     int mod = main_module_index;
-    if (mod == 14) mod = saved_module_for_menu;
-    g_zenv.ppu->extTilemapEnabled = (mod == 9 && submodule_index == 0 &&
-                                     g_zenv.ppu->extraLeftRight != 0);
+    bool is_ow_stable;
+    if (mod == 14)
+      is_ow_stable = (saved_module_for_menu == 9);
+    else
+      is_ow_stable = (mod == 9 && submodule_index == 0);
+    g_zenv.ppu->extTilemapEnabled = (is_ow_stable && g_zenv.ppu->extraLeftRight != 0);
   }
 
   if (g_zenv.ppu->extraLeftRight != 0 || render_flags & kPpuRenderFlags_Height240)

--- a/src/zelda_rtl.c
+++ b/src/zelda_rtl.c
@@ -197,10 +197,12 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
 
   // Enable extended tilemap before the clamp check so PpuSetExtraSideSpace
   // bypasses the tilemap_extra cap when we're on the overworld.
+  // Only during stable gameplay (submodule 0 = player control), not transitions.
   {
     int mod = main_module_index;
     if (mod == 14) mod = saved_module_for_menu;
-    g_zenv.ppu->extTilemapEnabled = (mod == 9 && g_zenv.ppu->extraLeftRight != 0);
+    g_zenv.ppu->extTilemapEnabled = (mod == 9 && submodule_index == 0 &&
+                                     g_zenv.ppu->extraLeftRight != 0);
   }
 
   if (g_zenv.ppu->extraLeftRight != 0 || render_flags & kPpuRenderFlags_Height240)

--- a/src/zelda_rtl.c
+++ b/src/zelda_rtl.c
@@ -10,6 +10,7 @@
 #include "spc_player.h"
 #include "util.h"
 #include "audio.h"
+#include "overworld.h"
 #include "assets.h"
 ZeldaEnv g_zenv;
 uint8 g_ram[131072];
@@ -194,8 +195,20 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
       PpuSetMode7PerspectiveCorrection(g_zenv.ppu, 0, 0);
   }
 
+  // Enable extended tilemap before the clamp check so PpuSetExtraSideSpace
+  // bypasses the tilemap_extra cap when we're on the overworld.
+  {
+    int mod = main_module_index;
+    if (mod == 14) mod = saved_module_for_menu;
+    g_zenv.ppu->extTilemapEnabled = (mod == 9 && g_zenv.ppu->extraLeftRight != 0);
+  }
+
   if (g_zenv.ppu->extraLeftRight != 0 || render_flags & kPpuRenderFlags_Height240)
     ConfigurePpuSideSpace();
+
+  // Fill extended tilemap with correct tile data for widescreen overflow
+  if (g_zenv.ppu->extTilemapEnabled)
+    Overworld_FillExtTilemap(g_zenv.ppu);
 
   int height = render_flags & kPpuRenderFlags_Height240 ? 240 : 224;
 

--- a/zelda3.ini
+++ b/zelda3.ini
@@ -1,15 +1,15 @@
 [General]
 # Automatically save state on quit and reload on start
-Autosave = 0
+Autosave = 1
 DisplayPerfInTitle = 0
 
-# Extended aspect ratio, either 16:9, 16:10, or 18:9. 4:3 means normal aspect ratio.
+# Extended aspect ratio, either 16:9, 16:10, 18:9, or 32:9. 4:3 means normal aspect ratio.
 # Add ", unchanged_sprites" to avoid changing sprite spawn/die behavior. Without this
 # replays will be incompatible.
 # Add ", no_visual_fixes" to avoid fixing some graphics glitches (for example with Cape).
 # It won't affect replays/game behavior but the memory compare will not work.
 # Add "extend_y, " right before the aspect radio specifier to display 240 lines instead of 224.
-ExtendedAspectRatio = 4:3
+ExtendedAspectRatio = 32:9
 
 # Disable the SDL_Delay that happens each frame (Gives slightly better perf if your
 # display is set to exactly 60hz)
@@ -26,7 +26,7 @@ DisableFrameDelay = 0
 WindowSize = Auto
 
 # Fullscreen mode (0=windowed, 1=desktop fullscreen, 2=fullscreen w/mode change)
-Fullscreen = 0
+Fullscreen = 1
 
 # Window scale (1=100%, 2=200%, 3=300%, etc.)
 WindowScale = 3


### PR DESCRIPTION
<img width="5120" height="1440" alt="image" src="https://github.com/user-attachments/assets/e883eb3a-2fee-4392-8b5f-8fa6f490bd8f" />

Hey everyone, I worked with Claude this week to add 32:9 ultrawide support to this project. There are a couple of things remaining:

- I would like to keep testing further
- I would like to spend more time understanding Claude's changes, which I believe is my responsibility as a contributor
- There are some useless files in here like shell.nix and I need to reset the ini file as well

### Description
This adds 32:9 support.

### Will this Pull Request break anything? 
It shouldn't!

### Suggested Testing Steps
Test on an ultrawide monitor.

### Claude's description of its own changes

Here's a summary of all changes since the `fbbb3f9` (Add BPS support) base:

#### 32:9 Ultra-Widescreen Support

These changes add support for 32:9 ultra-widescreen (796px viewport, 270px extra per side) to the zelda3 ALTTP reimplementation.

##### Build / Config
- **shell.nix** — Nix shell with SDL2, libGL, python3+pillow+pyyaml. Forces `-std=gnu17` because GCC 15 defaults to C23 which breaks old-style empty function parameter lists.
- **zelda3.ini** — Set to `32:9`, fullscreen, autosave enabled.
- **.gitignore** — Ignore `.agent-shell/` directory.

##### Bug Fixes
- **src/config.h** — `extended_aspect_ratio` changed from `uint8` to `uint16`. The value 270 (for 32:9) overflowed `uint8` max 255, silently wrapping to 14.
- **src/config.c** — Added `32:9` as a recognized aspect ratio string.
- **src/types.h** — `kPpuExtraLeftRight` increased from 96 to 320 to size PPU pixel buffers large enough for 32:9.
- **snes/ppu.h** — `extraLeftCur`, `extraRightCur`, `extraLeftRight` widened from `uint8_t` to `uint16_t` (values > 255 needed).

##### Extended Tilemap (core feature)
The SNES tilemap is 64 tiles wide (512px) with a ring buffer. To exceed this limit:

- **snes/ppu.h** — Added `extTilemap[0x1000]` (4 pages, 0x400 words each) and `extTilemapEnabled` flag to the `Ppu` struct. These hold tile data for columns beyond the 64-column VRAM tilemap.

- **snes/ppu.c — PpuDrawBackground_4bpp** (old renderer):
  - `tps[]` expanded from 2 to 4 page pointers. Pages 0-1 point to VRAM (ring buffer data), pages 2-3 point to `extTilemap` when enabled.
  - `NEXT_TP()` macro cycles through all 4 pages: 0→1→2→3→0.
  - Starting page forced to `(x >> 8) & 1` — always starts in VRAM, never in extTilemap.
  - Added `#undef NEXT_TP` before the 2bpp renderer to avoid redefinition warning.

- **snes/ppu.c — ppu_getPixelForBgLayer** (new renderer):
  - Computes distance from viewport left edge. If dist >= 512, reads from `extTilemap`; otherwise uses the original VRAM path.

- **snes/ppu.c — PpuSetExtraSideSpace**:
  - Bypasses the `tilemap_extra` clamp entirely when `extTilemapEnabled` is true, allowing the full 270px per side.

- **src/overworld.c — Overworld_FillExtTilemap()** (new function):
  - Called every frame during overworld mode (module 9).
  - Walks tile columns exactly as the renderer does, tracking the current page and position to write each tile to the correct destination (VRAM or extTilemap).
  - Uses two coordinate systems: PPU register scroll (10-bit wrapped) for tilemap addresses matching the renderer, and full game scroll (`BG1HOFS_copy2`/`BG2HOFS_copy2`) for map data lookup in `dung_bg1`/`dung_bg2`.
  - Processes both BG1 and BG2 layers.
  - Overwrites stale ring buffer VRAM data and fills extTilemap for overflow columns.

- **src/overworld.h** — Declares `Overworld_FillExtTilemap(struct Ppu *ppu)`.

- **src/zelda_rtl.c — ZeldaDrawPpuFrame**:
  - Sets `extTilemapEnabled = true` BEFORE `ConfigurePpuSideSpace()` so the clamp bypass takes effect.
  - Calls `Overworld_FillExtTilemap()` after `ConfigurePpuSideSpace()`.

##### Key bugs found and fixed during development
1. `uint8` overflow for aspect ratio value 270
2. VRAM fixup using absolute scroll coords for `dung_bg2` (which uses local area coords)
3. Renderer starting page using `& 3` instead of `& 1` — broke rendering when hScroll >= 256
4. PPU scroll registers are 10-bit (0-1023) but overworld uses full coordinates (1024+) — had to use `BG2HOFS_copy2` for map data lookup
5. ExtTilemap row addressing used game vScroll instead of PPU register vScroll, causing misalignment